### PR TITLE
Let clang use libc++.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ else()
   if(${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
     target_compile_options(ccls PRIVATE
                            $<$<CONFIG:Debug>:-fno-limit-debug-info>)
+    target_compile_options(ccls PRIVATE -stdlib=libc++)
   endif()
 
   if(ASAN)
@@ -81,6 +82,13 @@ if(NOT SYSTEM_CLANG)
   download_and_extract_clang(${CLANG_VERSION} ${CLANG_DOWNLOAD_LOCATION})
   # Used by FindClang
   set(CLANG_ROOT ${DOWNLOADED_CLANG_DIR})
+
+  if(${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
+    target_link_libraries(ccls PRIVATE ${CLANG_ROOT}/lib/libc++.a
+                                       ${CLANG_ROOT}/lib/libc++abi.a
+                                       ${CLANG_ROOT}/lib/libc++experimental.a)
+  endif()
+
 else()
   message(STATUS "Using system Clang")
 endif()


### PR DESCRIPTION
Clang use libstdc++ by default on linux and some C++17 header files may not be found in old gcc.