### PR TITLE
cmake: add clangBasic

### DIFF
--- a/cmake/FindClang.cmake
+++ b/cmake/FindClang.cmake
@@ -69,6 +69,7 @@ set(_Clang_REQUIRED_VARS Clang_LIBRARY Clang_INCLUDE_DIR Clang_EXECUTABLE
                          LLVM_INCLUDE_DIR LLVM_BUILD_INCLUDE_DIR)
 
 _Clang_find_library(Clang_LIBRARY clang)
+_Clang_find_add_library(clangBasic)
 _Clang_find_add_library(clangDriver)
 _Clang_find_add_library(LLVMOption)
 _Clang_find_add_library(LLVMSupport)


### PR DESCRIPTION
Fix build issue on Darwin:

```
Undefined symbols for architecture x86_64:
  "clang::ObjCRuntime::tryParse(llvm::StringRef)", referenced from:
      clang::driver::tools::Clang::AddObjCRuntimeArgs(llvm::opt::ArgList const&, llvm::SmallVector<char const*, 16u>&, clang::driver::tools::Clang::RewriteKind) const in libclangDriver.a(Clang.cpp.o)
  "clang::VersionTuple::tryParse(llvm::StringRef)", referenced from:
      clang::driver::ToolChain::computeMSVCVersion(clang::driver::Driver const*, llvm::opt::ArgList const&) const in libclangDriver.a(ToolChain.cpp.o)
  "clang::DiagnosticIDs::getDiagnosticFlags()", referenced from:
      clang::driver::Driver::handleAutocompletions(llvm::StringRef) const in libclangDriver.a(Driver.cpp.o)
  "clang::DiagnosticIDs::getCategoryNameFromID(unsigned int)", referenced from:
      clang::driver::Driver::HandleImmediateArgs(clang::driver::Compilation const&) in libclangDriver.a(Driver.cpp.o)
  "clang::DiagnosticIDs::getNumberOfCategories()", referenced from:
      clang::driver::Driver::HandleImmediateArgs(clang::driver::Compilation const&) in libclangDriver.a(Driver.cpp.o)
  ...

  "_compress2", referenced from:
      llvm::zlib::compress(llvm::StringRef, llvm::SmallVectorImpl<char>&, llvm::zlib::CompressionLevel) in libLLVMSupport.a(Compression.cpp.o)
  "_compressBound", referenced from:
      llvm::zlib::compress(llvm::StringRef, llvm::SmallVectorImpl<char>&, llvm::zlib::CompressionLevel) in libLLVMSupport.a(Compression.cpp.o)
  "_crc32", referenced from:
      llvm::zlib::crc32(llvm::StringRef) in libLLVMSupport.a(Compression.cpp.o)
  "_uncompress", referenced from:
      llvm::zlib::uncompress(llvm::StringRef, char*, unsigned long&) in libLLVMSupport.a(Compression.cpp.o)
ld: symbol(s) not found for architecture x86_64
clang-6.0: error: linker command failed with exit code 1 (use -v to see invocation)
```