### PR TITLE
fix clang_th.h && clang_complete.cc

### DIFF
--- a/src/clang_complete.cc
+++ b/src/clang_complete.cc
@@ -515,7 +515,7 @@ BuildCompilerInstance(CompletionSession &session,
         Preamble->Preamble.OverridePreamble(*CI, session.FS,
                                             Bufs.back().get());
 #else
-        Preamble->Preamble.AddImplicitPreamble(*CI, session->FS,
+        Preamble->Preamble.AddImplicitPreamble(*CI, session.FS,
                                                Bufs.back().get());
 #endif
       } else {

--- a/src/clang_tu.h
+++ b/src/clang_tu.h
@@ -17,6 +17,7 @@ limitations under the License.
 #include "position.h"
 
 #include <clang/Basic/SourceManager.h>
+#include <clang/Basic/LangOptions.h>
 
 #include <stdlib.h>
 

--- a/src/clang_tu.h
+++ b/src/clang_tu.h
@@ -16,8 +16,8 @@ limitations under the License.
 #pragma once
 #include "position.h"
 
-#include <clang/Basic/SourceManager.h>
 #include <clang/Basic/LangOptions.h>
+#include <clang/Basic/SourceManager.h>
 
 #include <stdlib.h>
 


### PR DESCRIPTION
fix compile errors for your latest commit.
```
clang version 6.0.1 (tags/RELEASE_601/final)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```