### PR TITLE
Remove chunks with CK_Information kind from insertText.

### DIFF
--- a/src/messages/textDocument_completion.cc
+++ b/src/messages/textDocument_completion.cc
@@ -426,7 +426,7 @@ void BuildItem(std::vector<lsCompletionItem> &out,
         out[i].insertText +=
             "${" + std::to_string(out[i].parameters_.size()) + ":" + text + "}";
         out[i].insertTextFormat = lsInsertTextFormat::Snippet;
-      } else {
+      } else if (Kind != CodeCompletionString::CK_Informative) {
         out[i].insertText += text;
       }
     }


### PR DESCRIPTION
Without this ccls inserts "size() const" in the following scenario:

std::string text;
text.si| <-- Trigger completion here and pick "size"

Fixes #77 