### PR TITLE
Fix compilation error on MSYS2 systems

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#define __STDC_FORMAT_MACROS
+
 #include "indexer.h"
 
 #include "clang_complete.hh"
@@ -762,8 +764,8 @@ public:
       switch (D->getKind()) {
       case Decl::CXXConversion: // *operator* int => *operator int*
       case Decl::CXXDestructor: // *~*A => *~A*
-      case Decl::CXXMethod: // *operator*= => *operator=*
-      case Decl::Function: // operator delete
+      case Decl::CXXMethod:     // *operator*= => *operator=*
+      case Decl::Function:      // operator delete
         if (Loc.isFileID()) {
           SourceRange R =
               cast<FunctionDecl>(OrigD)->getNameInfo().getSourceRange();
@@ -793,7 +795,7 @@ public:
         GetSymbolKind(cast<Decl>(SemDC), entity->def.parent_kind);
       } else if (is_decl) {
         DeclRef &dr = entity->declarations.emplace_back();
-        static_cast<Use&>(dr) = {{loc, role}, lid};
+        static_cast<Use &>(dr) = {{loc, role}, lid};
         SourceRange R = OrigD->getSourceRange();
         dr.extent = R.getBegin().isFileID() ? FromTokenRange(SM, Lang, R) : loc;
       } else {
@@ -1303,13 +1305,13 @@ Index(CompletionManager *completion, WorkingFiles *wfiles, VFS *vfs,
   {
     llvm::CrashRecoveryContext CRC;
     auto parse = [&]() {
-                   if (!Action->BeginSourceFile(*Clang, Clang->getFrontendOpts().Inputs[0]))
-                     return;
-                   if (!Action->Execute())
-                     return;
-                   Action->EndSourceFile();
-                   ok = true;
-                 };
+      if (!Action->BeginSourceFile(*Clang, Clang->getFrontendOpts().Inputs[0]))
+        return;
+      if (!Action->Execute())
+        return;
+      Action->EndSourceFile();
+      ok = true;
+    };
     if (!CRC.RunSafely(parse)) {
       LOG_S(ERROR) << "clang crashed for " << file;
       return {};


### PR DESCRIPTION
Hi,

Following the Windows build instructions [here](https://github.com/MaskRay/ccls/wiki/Build#windows), there is an error during compilation related to the `PRIu64` symbol. The detail of the error and information about the build system are below.

The problem is fixed by adding `#define __STDC_FORMAT_MACROS` at the top of `indexer.cc`


```
[28/54] Building CXX object CMakeFiles/ccls.dir/src/indexer.cc.obj
FAILED: CMakeFiles/ccls.dir/src/indexer.cc.obj
C:\msys64\mingw64\bin\c++.exe  -DDEFAULT_RESOURCE_DIRECTORY=R\"(C:\msys64\mingw64\lib\clang\7.0.0)\" -I../src -isystem ../third_party -isystem ../third_party/rapidjson/include -isystem C:/msys64/mingw64/include -O3 -DNDEBUG   -fno-rtti -Wall -Wno-sign-compare -Wno-return-type -Wno-unused-result -std=c++17 -MD -MT CMakeFiles/ccls.dir/src/indexer.cc.obj -MF CMakeFiles\ccls.dir\src\indexer.cc.obj.d -o CMakeFiles/ccls.dir/src/indexer.cc.obj -c ../src/indexer.cc
../src/indexer.cc: In function 'void Reflect(Writer&, SymbolRef&)':
../src/indexer.cc:1385:37: error: expected ')' before 'PRIu64'
     snprintf(buf, sizeof buf, "%s|%" PRIu64 "|%d|%d",
             ~                       ^~~~~~~
                                     )
../src/indexer.cc:1385:31: warning: spurious trailing '%' in format [-Wformat=]
     snprintf(buf, sizeof buf, "%s|%" PRIu64 "|%d|%d",
                               ^~~~~~
../src/indexer.cc:1385:31: warning: too many arguments for format [-Wformat-extra-args]
```

```
$ cmake .. -G Ninja  -DSYSTEM_CLANG=ON
-- The CXX compiler identification is GNU 8.2.0
-- Check for working CXX compiler: C:/msys64/mingw64/bin/c++.exe
-- Check for working CXX compiler: C:/msys64/mingw64/bin/c++.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Setting build type to 'Release' as none was specified.
-- Using system Clang
-- Found Clang: C:/msys64/mingw64/lib/libclangIndex.a (found suitable version "7.0.0", minimum required is "6.0.0")
-- Looking for cbreak in C:/msys64/mingw64/lib/libncurses.a
-- Looking for cbreak in C:/msys64/mingw64/lib/libncurses.a - found
-- Found Curses: C:/msys64/mingw64/lib/libncurses.a
-- Found ZLIB: C:/msys64/mingw64/lib/libz.dll.a (found version "1.2.11")
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/rdeterre/ccls/build
```