### PR TITLE
-DSYSTEM_CLANG=OFF: allow using Ubuntu 14.04

### DIFF
--- a/cmake/DownloadAndExtractClang.cmake
+++ b/cmake/DownloadAndExtractClang.cmake
@@ -12,8 +12,41 @@ set(CLANG_ARCHIVE_EXT .tar.xz)
 if(${CMAKE_SYSTEM_NAME} STREQUAL Linux)
 
   # Default to Ubuntu 16.04
-  set(CLANG_ARCHIVE_NAME
-      clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-16.04)
+  set(DEFAULT_UBUNTU_VERSION_NUMBER 16.04)
+
+  # Select a Clang archive for other Ubuntu releases if the current platform
+  # differs from the default one
+  set(UBUNTU_VERSION_NUMBER ${DEFAULT_UBUNTU_VERSION_NUMBER})
+  find_program(LSB_RELEASE_EXECUTABLE lsb_release)
+
+  if(NOT LSB_RELEASE_EXECUTABLE)
+    message(WARNING "Could not find lsb_release executable. \
+Falling back to default Linux platform: Clang/LLVM archive for \
+Ubuntu ${DEFAULT_UBUNTU_VERSION_NUMBER}.")
+
+  else()
+    execute_process(COMMAND ${LSB_RELEASE_EXECUTABLE} -si
+      OUTPUT_VARIABLE LSB_RELEASE_ID
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+
+    if(${LSB_RELEASE_ID} STREQUAL Ubuntu)
+      execute_process(COMMAND ${LSB_RELEASE_EXECUTABLE} -sr
+        OUTPUT_VARIABLE LSB_RELEASE_NUMBER
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+      set(UBUNTU_VERSION_NUMBER ${LSB_RELEASE_NUMBER})
+
+    else()
+      message(WARNING "Identified other Linux platform than Ubuntu. Falling \
+back to default: Clang/LLVM for Ubuntu ${DEFAULT_UBUNTU_VERSION_NUMBER}.")
+
+    endif()
+  endif()
+
+  set(CLANG_ARCHIVE_NAME "clang+llvm-${CLANG_VERSION}-x86_64-\
+linux-gnu-ubuntu-${UBUNTU_VERSION_NUMBER}")
 
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
 

--- a/src/messages/ccls_inheritance.cc
+++ b/src/messages/ccls_inheritance.cc
@@ -197,10 +197,16 @@ struct Handler_textDocumentImplementation
     : BaseMessageHandler<In_textDocumentImplementation> {
   MethodType GetMethodType() const override { return implementation; }
   void Run(In_textDocumentImplementation *request) override {
+    Handler_cclsInheritance handler;
+    handler.db = db;
+    handler.project = project;
+    handler.working_files = working_files;
+
     In_cclsInheritance request1;
+    request1.id = request->id;
     request1.params.textDocument = request->params.textDocument;
     request1.params.position = request->params.position;
-    Handler_cclsInheritance().Run(&request1);
+    handler.Run(&request1);
   }
 };
 REGISTER_MESSAGE_HANDLER(Handler_textDocumentImplementation);

--- a/src/messages/textDocument_completion.cc
+++ b/src/messages/textDocument_completion.cc
@@ -227,6 +227,10 @@ void FilterCandidates(lsCompletionList &result,
               items.end());
   std::sort(items.begin(), items.end(),
             [](const lsCompletionItem &lhs, const lsCompletionItem &rhs) {
+              int t = int(lhs.additionalTextEdits.size() -
+                          rhs.additionalTextEdits.size());
+              if (t)
+                return t < 0;
               if (lhs.score_ != rhs.score_)
                 return lhs.score_ > rhs.score_;
               if (lhs.priority_ != rhs.priority_)


### PR DESCRIPTION
In the 6.0.1 -> 7.0.0 LLVM migration of f27639babfd7a29c8c76681e99c015d1f3e4a676, archive hashes were added for the LLVM 7.0.0 binaries not only for Ubuntu 16.04, but also for Ubuntu 14.04. Afaics, the `DownloadAndExtractClang.cmake` functionality would never allow making use of the latter, however; always using the Ubuntu 16.04 LLVM 7.0.0 binary in case of OS Linux.

This commit generalizes the archive name derivation for when the current platform is Ubuntu, while persisting using Ubuntu 16.04 as default archive in case CMAKE_SYSTEM_NAME is Linux (even if the actual dist is not Ubuntu).

This change will also facilitate keeping backwards compatibility with Ubuntu 16.04 (possibly 14.04) for the upcoming LLVM 8.0.0 migration, where an archive for Bionic (18.04) is expected to be included (which may be chosen as the default).

If this just adds unneeded complexity to `DownloadAndExtractClang.cmake`, we could alternatively simply remove `clang_archive_hashes/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz.SHA256`.