### PR TITLE
Declare documentLink is not supported in capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ target_sources(ccls PRIVATE
   src/messages/textDocument_completion.cc
   src/messages/textDocument_definition.cc
   src/messages/textDocument_did.cc
+  src/messages/textDocument_foldingRange.cc
   src/messages/textDocument_formatting.cc
   src/messages/textDocument_documentHighlight.cc
   src/messages/textDocument_documentSymbol.cc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ccls, which originates from [cquery](https://github.com/cquery-project/cquery), is a C/C++/Objective-C language server.
 
   * code completion (with both signature help and snippets)
-  * [definition](src/messages/textDocument_definition.cc)/[references](src/messages/textDcument_references.cc), and other cross references
+  * [definition](src/messages/textDocument_definition.cc)/[references](src/messages/textDocument_references.cc), and other cross references
   * cross reference extensions: `$ccls/call` `$ccls/inheritance` `$ccls/member` `$ccls/vars` ...
   * formatting
   * hierarchies: [call (caller/callee) hierarchy](src/messages/ccls_call.cc), [inheritance (base/derived) hierarchy](src/messages/ccls_inheritance.cc), [member hierarchy](src/messages/ccls_member.cc)

--- a/src/messages/ccls_inheritance.cc
+++ b/src/messages/ccls_inheritance.cc
@@ -197,10 +197,16 @@ struct Handler_textDocumentImplementation
     : BaseMessageHandler<In_textDocumentImplementation> {
   MethodType GetMethodType() const override { return implementation; }
   void Run(In_textDocumentImplementation *request) override {
+    Handler_cclsInheritance handler;
+    handler.db = db;
+    handler.project = project;
+    handler.working_files = working_files;
+
     In_cclsInheritance request1;
+    request1.id = request->id;
     request1.params.textDocument = request->params.textDocument;
     request1.params.position = request->params.position;
-    Handler_cclsInheritance().Run(&request1);
+    handler.Run(&request1);
   }
 };
 REGISTER_MESSAGE_HANDLER(Handler_textDocumentImplementation);

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -172,6 +172,7 @@ struct lsServerCapabilities {
   bool renameProvider = true;
   // The server provides document link support.
   lsDocumentLinkOptions documentLinkProvider;
+  bool foldingRangeProvider = true;
   // The server provides execute command support.
   struct ExecuteCommandOptions {
     std::vector<std::string> commands{std::string(ccls_xref)};
@@ -196,7 +197,8 @@ MAKE_REFLECT_STRUCT(lsServerCapabilities, textDocumentSync, hoverProvider,
                     codeLensProvider, documentFormattingProvider,
                     documentRangeFormattingProvider,
                     documentOnTypeFormattingProvider, renameProvider,
-                    documentLinkProvider, executeCommandProvider, workspace);
+                    documentLinkProvider, foldingRangeProvider,
+                    executeCommandProvider, workspace);
 
 // Workspace specific client capabilities.
 struct lsWorkspaceClientCapabilites {

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -74,13 +74,6 @@ struct lsDocumentOnTypeFormattingOptions {
 MAKE_REFLECT_STRUCT(lsDocumentOnTypeFormattingOptions, firstTriggerCharacter,
                     moreTriggerCharacter);
 
-// Document link options
-struct lsDocumentLinkOptions {
-  // Document links have a resolve provider as well.
-  bool resolveProvider = false;
-};
-MAKE_REFLECT_STRUCT(lsDocumentLinkOptions, resolveProvider);
-
 // Save options.
 struct lsSaveOptions {
   // The client is supposed to include the content on save.
@@ -170,8 +163,6 @@ struct lsServerCapabilities {
   lsDocumentOnTypeFormattingOptions documentOnTypeFormattingProvider;
   // The server provides rename support.
   bool renameProvider = true;
-  // The server provides document link support.
-  lsDocumentLinkOptions documentLinkProvider;
   bool foldingRangeProvider = true;
   // The server provides execute command support.
   struct ExecuteCommandOptions {
@@ -197,8 +188,7 @@ MAKE_REFLECT_STRUCT(lsServerCapabilities, textDocumentSync, hoverProvider,
                     codeLensProvider, documentFormattingProvider,
                     documentRangeFormattingProvider,
                     documentOnTypeFormattingProvider, renameProvider,
-                    documentLinkProvider, foldingRangeProvider,
-                    executeCommandProvider, workspace);
+                    foldingRangeProvider, executeCommandProvider, workspace);
 
 // Workspace specific client capabilities.
 struct lsWorkspaceClientCapabilites {

--- a/src/messages/textDocument_completion.cc
+++ b/src/messages/textDocument_completion.cc
@@ -227,6 +227,10 @@ void FilterCandidates(lsCompletionList &result,
               items.end());
   std::sort(items.begin(), items.end(),
             [](const lsCompletionItem &lhs, const lsCompletionItem &rhs) {
+              int t = int(lhs.additionalTextEdits.size() -
+                          rhs.additionalTextEdits.size());
+              if (t)
+                return t < 0;
               if (lhs.score_ != rhs.score_)
                 return lhs.score_ > rhs.score_;
               if (lhs.priority_ != rhs.priority_)

--- a/src/messages/textDocument_foldingRange.cc
+++ b/src/messages/textDocument_foldingRange.cc
@@ -1,0 +1,73 @@
+/* Copyright 2017-2018 ccls Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "message_handler.h"
+#include "pipeline.hh"
+#include "project.h"
+#include "query_utils.h"
+#include "working_files.h"
+
+namespace ccls {
+namespace {
+MethodType foldingRange = "textDocument/foldingRange";
+
+struct In_textDocumentFoldingRange : public RequestMessage {
+  MethodType GetMethodType() const override { return foldingRange; }
+  struct Params {
+    lsTextDocumentIdentifier textDocument;
+  } params;
+};
+MAKE_REFLECT_STRUCT(In_textDocumentFoldingRange::Params, textDocument);
+MAKE_REFLECT_STRUCT(In_textDocumentFoldingRange, id, params);
+REGISTER_IN_MESSAGE(In_textDocumentFoldingRange);
+
+struct FoldingRange {
+  int startLine, startCharacter, endLine, endCharacter;
+  std::string kind = "region";
+};
+MAKE_REFLECT_STRUCT(FoldingRange, startLine, startCharacter, endLine, endCharacter, kind);
+
+struct Handler_textDocumentFoldingRange
+    : BaseMessageHandler<In_textDocumentFoldingRange> {
+  MethodType GetMethodType() const override { return foldingRange; }
+  void Run(In_textDocumentFoldingRange *request) override {
+    QueryFile *file;
+    if (!FindFileOrFail(db, project, request->id,
+                        request->params.textDocument.uri.GetPath(), &file,
+                        nullptr))
+      return;
+    WorkingFile *wfile =
+        working_files->GetFileByFilename(file->def->path);
+    if (!wfile)
+      return;
+    std::vector<FoldingRange> result;
+    std::optional<lsRange> ls_range;
+
+    for (auto [sym, refcnt] : file->symbol2refcnt)
+      if (refcnt > 0 && sym.extent.Valid() &&
+          (sym.kind == SymbolKind::Func || sym.kind == SymbolKind::Type) &&
+          (ls_range = GetLsRange(wfile, sym.extent))) {
+        FoldingRange &fold = result.emplace_back();
+        fold.startLine = ls_range->start.line;
+        fold.startCharacter = ls_range->start.character;
+        fold.endLine = ls_range->end.line;
+        fold.endCharacter = ls_range->end.character;
+      }
+    pipeline::Reply(request->id, result);
+  }
+};
+REGISTER_MESSAGE_HANDLER(Handler_textDocumentFoldingRange);
+} // namespace
+} // namespace ccls


### PR DESCRIPTION
Otherwise clients may still send textDocument/documentLink requests and wait indefinitely for responses.