### PR TITLE
Spin IncludeComplete's destructor until scanning completes

### DIFF
--- a/src/include_complete.cc
+++ b/src/include_complete.cc
@@ -102,6 +102,13 @@ CompletionItem BuildCompletionItem(const std::string &path,
 IncludeComplete::IncludeComplete(Project *project)
     : is_scanning(false), project_(project) {}
 
+IncludeComplete::~IncludeComplete() {
+  // Spin until the scanning has completed.
+  while(is_scanning.load()){
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  };
+}
+
 void IncludeComplete::Rescan() {
   if (is_scanning || LLVM_VERSION_MAJOR >= 8)
     return;

--- a/src/include_complete.hh
+++ b/src/include_complete.hh
@@ -26,6 +26,7 @@ struct Project;
 
 struct IncludeComplete {
   IncludeComplete(Project *project);
+  ~IncludeComplete();
 
   // Starts scanning directories. Clears existing cache.
   void Rescan();


### PR DESCRIPTION
Fixes a segfault when trying to access the group matcher in the scanning thread after IncludeComplete has been destroyed