### PR TITLE
textDocument/didOpen: index related files when a header is opened

### DIFF
--- a/src/messages/textDocument_did.cc
+++ b/src/messages/textDocument_did.cc
@@ -53,10 +53,12 @@ void MessageHandler::textDocument_didOpen(DidOpenTextDocumentParam &param) {
 
   // Submit new index request if it is not a header file or there is no
   // pending index request.
-  std::pair<LanguageId, bool> lang = lookupExtension(path);
-  if ((lang.first != LanguageId::Unknown && !lang.second) ||
+  auto [lang, header] = lookupExtension(path);
+  if ((lang != LanguageId::Unknown && !header) ||
       !pipeline::pending_index_requests)
     pipeline::Index(path, {}, IndexMode::Normal, false);
+  if (header)
+    project->IndexRelated(path);
 
   manager->OnView(path);
 }

--- a/src/project.cc
+++ b/src/project.cc
@@ -532,4 +532,22 @@ void Project::Index(WorkingFiles *wfiles, RequestId id) {
   // trigger refreshing semantic highlight for all working files.
   pipeline::Index("", {}, IndexMode::NonInteractive, false);
 }
+
+void Project::IndexRelated(const std::string &path) {
+  auto &gi = g_config->index;
+  GroupMatch match(gi.whitelist, gi.blacklist);
+  std::string stem = sys::path::stem(path);
+  std::lock_guard lock(mtx);
+  for (auto &[root, folder] : root2folder)
+    if (StringRef(path).startswith(root)) {
+      for (const Project::Entry &entry : folder.entries) {
+        std::string reason;
+        if (sys::path::stem(entry.filename) == stem && entry.filename != path &&
+            match.Matches(entry.filename, &reason))
+          pipeline::Index(entry.filename, entry.args, IndexMode::NonInteractive,
+                          true);
+      }
+      break;
+    }
+}
 } // namespace ccls

--- a/src/project.hh
+++ b/src/project.hh
@@ -77,5 +77,6 @@ struct Project {
                       const std::string &path);
 
   void Index(WorkingFiles *wfiles, RequestId id);
+  void IndexRelated(const std::string &path);
 };
 } // namespace ccls


### PR DESCRIPTION
Fix #180

For larger code bases, index.initialBlacklist: ["."] is useful to inhibit initial indexing.
Opened files are still indexed, this heuristic allows related files to be indexed when a header is opened.