### PR TITLE
log to stderr to forward to lsp client

### DIFF
--- a/src/log.cc
+++ b/src/log.cc
@@ -67,11 +67,14 @@ Message::Message(Verbosity verbosity, const char *file, int line)
 }
 
 Message::~Message() {
-  if (!file)
-    return;
   std::lock_guard<std::mutex> lock(mtx);
   stream_ << '\n';
-  fputs(stream_.str().c_str(), file);
+  if (file) {
+    fputs(stream_.str().c_str(), file);
+    fflush(file);
+  }
+  fputs(stream_.str().c_str(), stderr);
+  fflush(stderr); // stderr is redirected to LSP client
   if (verbosity_ == Verbosity_FATAL)
     abort();
 }


### PR DESCRIPTION
This allows to forward logs to LSP client:
![image](https://user-images.githubusercontent.com/7345761/51428045-21955500-1c10-11e9-925b-11738b84028e.png)
