### PR TITLE
Use DiagnosticRelatedInformation in clients that support it

### DIFF
--- a/src/config.hh
+++ b/src/config.hh
@@ -108,6 +108,8 @@ struct Config {
     bool linkSupport = true;
     // TextDocumentClientCapabilities.completion.completionItem.snippetSupport
     bool snippetSupport = true;
+    // TextDocumentClientCapabilities.publishDiagnostics.relatedInformation
+    bool diagnosticsRelatedInformation = true;
   } client;
 
   struct CodeLens {

--- a/src/lsp.hh
+++ b/src/lsp.hh
@@ -238,12 +238,18 @@ struct WorkspaceFolder {
 enum class MessageType : int { Error = 1, Warning = 2, Info = 3, Log = 4 };
 REFLECT_UNDERLYING(MessageType)
 
+struct DiagnosticRelatedInformation {
+  Location location;
+  std::string message;
+};
+
 struct Diagnostic {
   lsRange range;
   int severity = 0;
   int code = 0;
   std::string source = "ccls";
   std::string message;
+  std::vector<DiagnosticRelatedInformation> relatedInformation;
   std::vector<TextEdit> fixits_;
 };
 

--- a/src/message_handler.hh
+++ b/src/message_handler.hh
@@ -195,7 +195,8 @@ REFLECT_STRUCT(TextDocumentIdentifier, uri);
 REFLECT_STRUCT(TextDocumentItem, uri, languageId, version, text);
 REFLECT_STRUCT(TextEdit, range, newText);
 REFLECT_STRUCT(VersionedTextDocumentIdentifier, uri, version);
-REFLECT_STRUCT(Diagnostic, range, severity, code, source, message);
+REFLECT_STRUCT(DiagnosticRelatedInformation, location, message);
+REFLECT_STRUCT(Diagnostic, range, severity, code, source, message, relatedInformation);
 REFLECT_STRUCT(ShowMessageParam, type, message);
 REFLECT_UNDERLYING_B(LanguageId);
 

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -171,6 +171,10 @@ struct TextDocumentClientCap {
   struct DocumentSymbol {
     bool hierarchicalDocumentSymbolSupport = false;
   } documentSymbol;
+
+  struct PublishDiagnostics {
+    bool relatedInformation = false;
+  } publishDiagnostics;
 };
 
 REFLECT_STRUCT(TextDocumentClientCap::Completion::CompletionItem,
@@ -179,7 +183,8 @@ REFLECT_STRUCT(TextDocumentClientCap::Completion, completionItem);
 REFLECT_STRUCT(TextDocumentClientCap::DocumentSymbol,
                hierarchicalDocumentSymbolSupport);
 REFLECT_STRUCT(TextDocumentClientCap::LinkSupport, linkSupport);
-REFLECT_STRUCT(TextDocumentClientCap, completion, definition, documentSymbol);
+REFLECT_STRUCT(TextDocumentClientCap::PublishDiagnostics, relatedInformation);
+REFLECT_STRUCT(TextDocumentClientCap, completion, definition, documentSymbol, publishDiagnostics);
 
 struct ClientCap {
   WorkspaceClientCap workspace;
@@ -306,6 +311,8 @@ void Initialize(MessageHandler *m, InitializeParam &param, ReplyOnce &reply) {
       capabilities.textDocument.definition.linkSupport;
   g_config->client.snippetSupport &=
       capabilities.textDocument.completion.completionItem.snippetSupport;
+  g_config->client.diagnosticsRelatedInformation &=
+      capabilities.textDocument.publishDiagnostics.relatedInformation;
   didChangeWatchedFiles =
       capabilities.workspace.didChangeWatchedFiles.dynamicRegistration;
 


### PR DESCRIPTION
In clients that support DiagnosticRelatedInformation, display
clang notes as these nested diagnostics rather than appending
them to the parent diagnostic's message. Behaviour for clients
that don't support related information should be unchanged.