### PR TITLE
Treat CR, LF, CRLF as the same linefeed markers in ToLines

### DIFF
--- a/src/working_files.cc
+++ b/src/working_files.cc
@@ -57,10 +57,23 @@ Position GetPositionForOffset(const std::string &content, int offset) {
 
 std::vector<std::string> ToLines(const std::string &content) {
   std::vector<std::string> result;
-  std::istringstream lines(content);
-  std::string line;
-  while (getline(lines, line))
-    result.push_back(line);
+  size_t startPos = 0;
+  while (startPos < content.size()) {
+    // \r or \n
+    size_t endPos = content.find_first_of("\r\n", startPos);
+    if (endPos == std::string::npos) {
+      // EOF
+      result.push_back(content.substr(startPos));
+      break;
+    }
+    result.push_back(content.substr(startPos, endPos - startPos));
+    if (content[endPos] == '\r' && endPos < content.size() - 1 &&
+        content[endPos + 1] == '\n') {
+      // \r\n
+      endPos++;
+    }
+    startPos = endPos + 1;
+  }
   return result;
 }
 


### PR DESCRIPTION
According to [LSP spec](https://microsoft.github.io/language-server-protocol/specification#text-documents), we have
> To ensure that both client and server split the string into the same line representation the protocol specifies the following end-of-line sequences: ‘\n’, ‘\r\n’ and ‘\r’.
>
> Positions are line end character agnostic. So you can not specify a position that denotes \r|\n or \n| where | represents the character offset.

If we split the lines only with `\n` as delimiter, for files using `\r` or `\r\n` as linefeed, there will eventually be mismatch between lines we keep in the index (break lines with `ToLines`), and the lines sent from LSP client (break lines by LSP client, e.g. VSCode). This will cause trouble for `ComputeLineMapping`, because two same set of lines are treated as if they are different from each other.

I tried some simple files in VSCode: [line-endings-test.zip](https://github.com/MaskRay/ccls/files/2915775/line-endings-test.zip). It can be observed that when VSCode sends `textDocument/didOpen` notification, based on the assumption above, it simply uses the linefeed as it's configured by user to use. This can cause trouble if user is editing a file with mixed linefeed, or for VSCode, `\r` as linefeed, because VSCode does not have `\r` option on Windows.

This is the notification sent for a file ends with `\r`
```json
{
    "jsonrpc": "2.0",
    "method": "textDocument/didOpen",
    "params": {
        "textDocument": {
            "uri": "file://.../line-endings-cr.cpp",
            "languageId": "cpp",
            "version": 1,
            "text": "#include <iostream>\r\n#include <string>\r\n#include <algorithm>\r\n#include <unordered_set>\r\n\r\nchar c[] = \"abc\r\ndef\r\nghi\";"
        }
    }
}
```

This is the notification sent for a file ends with mixed linefeed
```json
{
    "jsonrpc": "2.0",
    "method": "textDocument/didOpen",
    "params": {
        "textDocument": {
            "uri": "file:///.../line-endings-mixed.cpp",
            "languageId": "cpp",
            "version": 1,
            "text": "#include <iostream>\r\n#include <string>\r\n#include <algorithm>\r\n#include <unordered_set>\r\n\r\nchar c[] = \"abc\r\ndef\r\nghi\";"
        }
    }
}
```