### PR TITLE
Add clang.excludeGlobs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ cquery has system include path detection (through running the compiler driver) w
 # >>> [Getting started](../../wiki/Home) (CLICK HERE) <<<
 
 * [Build](../../wiki/Build)
-* [Client feature table](../../wiki/Client-feature-table)
 * [FAQ](../../wiki/FAQ)
 
 ccls can index itself (~180MiB RSS when idle, noted on 2018-09-01), FreeBSD, glibc, Linux, LLVM (~1800MiB RSS), musl (~60MiB RSS), ... with decent memory footprint. See [wiki/compile_commands.json](../../wiki/compile_commands.json) for examples.

--- a/src/config.hh
+++ b/src/config.hh
@@ -101,6 +101,10 @@ struct Config {
     // e.g. If your project is built by GCC and has an option thag clang does not understand.
     std::vector<std::string> excludeArgs;
 
+    // Arguments matching any of these glob patterns will be excluded.
+    // * ? and [] metacharacters are supported.
+    std::vector<std::string> excludeGlobs;
+
     // Additional arguments to pass to clang.
     std::vector<std::string> extraArgs;
 
@@ -323,8 +327,8 @@ REFLECT_STRUCT(Config::ServerCap::Workspace::WorkspaceFolders, supported,
 REFLECT_STRUCT(Config::ServerCap::Workspace, workspaceFolders);
 REFLECT_STRUCT(Config::ServerCap, documentOnTypeFormattingProvider,
                foldingRangeProvider, workspace);
-REFLECT_STRUCT(Config::Clang, excludeArgs, extraArgs, pathMappings,
-               resourceDir);
+REFLECT_STRUCT(Config::Clang, excludeArgs, excludeGlobs, extraArgs,
+               pathMappings, resourceDir);
 REFLECT_STRUCT(Config::ClientCapability, hierarchicalDocumentSymbolSupport,
                linkSupport, snippetSupport);
 REFLECT_STRUCT(Config::CodeLens, localVariables);

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -473,7 +473,8 @@ public:
       info.usr = HashUsr(USR);
       if (auto *ND = dyn_cast<NamedDecl>(D)) {
         info.short_name = ND->getNameAsString();
-        info.qualified = ND->getQualifiedNameAsString();
+        llvm::raw_string_ostream OS(info.qualified);
+        ND->printQualifiedName(OS, GetDefaultPolicy());
         SimplifyAnonymous(info.qualified);
       }
     }


### PR DESCRIPTION
This option allows to disable compilations options matching any of specified glob patterns. '*', '?', '[' and ']' metacharacters are supported. One use case is cross-compiling linux kernel: `ccls  -index=. '-init={"clang" : {"excludeGlobs" : ["-m*", "-W*", "-f*"]}}'` correctly indexes kernel sources using unmodified `compile_commands.json` obtained from `bear make`.