### PR TITLE
Handle case when column==NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ cquery has system include path detection (through running the compiler driver) w
 # >>> [Getting started](../../wiki/Home) (CLICK HERE) <<<
 
 * [Build](../../wiki/Build)
-* [Client feature table](../../wiki/Client-feature-table)
 * [FAQ](../../wiki/FAQ)
 
 ccls can index itself (~180MiB RSS when idle, noted on 2018-09-01), FreeBSD, glibc, Linux, LLVM (~1800MiB RSS), musl (~60MiB RSS), ... with decent memory footprint. See [wiki/compile_commands.json](../../wiki/compile_commands.json) for examples.

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -473,7 +473,8 @@ public:
       info.usr = HashUsr(USR);
       if (auto *ND = dyn_cast<NamedDecl>(D)) {
         info.short_name = ND->getNameAsString();
-        info.qualified = ND->getQualifiedNameAsString();
+        llvm::raw_string_ostream OS(info.qualified);
+        ND->printQualifiedName(OS, GetDefaultPolicy());
         SimplifyAnonymous(info.qualified);
       }
     }

--- a/src/working_files.cc
+++ b/src/working_files.cc
@@ -326,7 +326,7 @@ void WorkingFile::ComputeLineMapping() {
 
 std::optional<int> WorkingFile::GetBufferPosFromIndexPos(int line, int *column,
                                                          bool is_end) {
-  if (line == (int)index_lines.size() && !*column)
+  if (line == (int)index_lines.size() && (column == NULL || !*column))
     return buffer_content.size();
   if (line < 0 || line >= (int)index_lines.size()) {
     LOG_S(WARNING) << "bad index_line (got " << line << ", expected [0, "


### PR DESCRIPTION
On Red Hat 4.8.5 using ccls from emacs lsp, ccls will crash repeatedly.
I was able to track the crash down to GetBufferPosFromIndexPos. The "int *column" parameter is, at times, NULL (this was found by attaching to ccls with gdb before it crashed).
GetBufferPosFromIndexPos assumes that "column" is never NULL, and it dereferences "column" immediately, leading to the crash.
The actual root of this bug may be in other code that inadvertently calls GetBufferPosFromIndexPos with a NULL parameter, but this patch fixed the crash for me completely and got ccls back in perfect working condition.