### PR TITLE
always use complete path as index lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ cquery has system include path detection (through running the compiler driver) w
 # >>> [Getting started](../../wiki/Home) (CLICK HERE) <<<
 
 * [Build](../../wiki/Build)
-* [Client feature table](../../wiki/Client-feature-table)
 * [FAQ](../../wiki/FAQ)
 
 ccls can index itself (~180MiB RSS when idle, noted on 2018-09-01), FreeBSD, glibc, Linux, LLVM (~1800MiB RSS), musl (~60MiB RSS), ... with decent memory footprint. See [wiki/compile_commands.json](../../wiki/compile_commands.json) for examples.

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -473,7 +473,8 @@ public:
       info.usr = HashUsr(USR);
       if (auto *ND = dyn_cast<NamedDecl>(D)) {
         info.short_name = ND->getNameAsString();
-        info.qualified = ND->getQualifiedNameAsString();
+        llvm::raw_string_ostream OS(info.qualified);
+        ND->printQualifiedName(OS, GetDefaultPolicy());
         SimplifyAnonymous(info.qualified);
       }
     }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -113,7 +113,17 @@ std::string LowerPathIfInsensitive(const std::string &path) {
     c = tolower(c);
   return ret;
 #else
-  return path;
+  // use this opportunity to get full path
+  char *rpbuf = NULL;
+  std::string fullpath;
+  rpbuf = realpath(path.c_str(), NULL);
+  if (rpbuf != NULL) {
+    fullpath = rpbuf;
+    free(rpbuf);
+  } else {
+    fullpath = path;
+  }
+  return fullpath;
 #endif
 }
 


### PR DESCRIPTION
When using ccls from emacs LSP, I would constantly get "not indexed" errors.
The source code being indexed is on a GPFS filesystem that has a "friendly" pathname, and the actual (more convoluted) gpfs pathname.
ccls would index the file under the convoluted pathname, then try to retrieve it using the friendly pathname, resulting in constant "not indexed" errors. By forcing ccls to use the full pathname with this patch, it will always uses the same key to reference the source code index, and always gets the correct result.
ccls was completely borken for me and with this patch it is working flawlessly. I would guess that this multiple-pathname problem would also be an issue for anyone with symlinks in their projects, this patch should fix those cases as well.