### PR TITLE
Hide all function declarations in documentSymbol.

### DIFF
--- a/src/indexer.hh
+++ b/src/indexer.hh
@@ -45,7 +45,7 @@ using Usr = uint64_t;
 
 // The order matters. In FindSymbolsAtLocation, we want Var/Func ordered in
 // front of others.
-enum class Kind : uint8_t { Invalid, File, Type, Func, Var };
+enum class Kind : uint8_t { Invalid, File, Type, Func, FuncDecl, Var };
 REFLECT_UNDERLYING_B(Kind);
 
 enum class Role : uint16_t {

--- a/src/messages/textDocument_document.cc
+++ b/src/messages/textDocument_document.cc
@@ -182,6 +182,9 @@ void MessageHandler::textDocument_documentSymbol(JsonReader &reader,
     for (auto [sym, refcnt] : file->symbol2refcnt) {
       if (refcnt <= 0 || !sym.extent.Valid())
         continue;
+      // For now we do not show function decl because there can be multiple items.
+      if (sym.kind == Kind::FuncDecl)
+        continue;
       auto r = sym2ds.try_emplace(SymbolIdx{sym.usr, sym.kind});
       if (!r.second)
         continue;

--- a/src/query.cc
+++ b/src/query.cc
@@ -310,9 +310,9 @@ void DB::ApplyIndexUpdate(IndexUpdate *u) {
   Update(lid2file_id, u->file_id, std::move(u->funcs_def_update));
   for (auto &[usr, del_add]: u->funcs_declarations) {
     for (DeclRef &dr : del_add.first)
-      RefDecl(prev_lid2file_id, usr, Kind::Func, dr, -1);
+      RefDecl(prev_lid2file_id, usr, Kind::FuncDecl, dr, -1);
     for (DeclRef &dr : del_add.second)
-      RefDecl(lid2file_id, usr, Kind::Func, dr, 1);
+      RefDecl(lid2file_id, usr, Kind::FuncDecl, dr, 1);
   }
   REMOVE_ADD(func, declarations);
   REMOVE_ADD(func, derived);


### PR DESCRIPTION
In current implementation of `textDocument/documentSymbol`, for function symbols of same {USR, Kind} in the same file, the returned function symbol will randomly be either one of the declarations, or the defintion. Consider a file containing both declaration(s) and implementation of a function. Because there is no way to distinguish between function declaration and its defintion with `ccls::Kind::Func` enum, {USR, Kind} pair collides in `sym2ds` map in `MessageHandler::textDocument_documentSymbol`.

When {USR, Kind} pair collides, the first seen symbol in `file->symbol2refcnt` dictionary wins and gets returned. This causes instability in `documentSymbol` result. For now, removing all the function declarations while keeping all the function defintions can make documentSymbol result determinstic (so is the "document outline" content in VSCode).

Further improvements, such as also showing function declarations in documentSymbol, IMO, depends on some sort of refactor of `textDocument_documentSymbol`. Perhaps we may allow `FuncDecl`s of same function to appear multiple times in the same file, and choose the correct `FuncDecl`/`Func` as the child of a Type considering the LsRange? It's only a rought thought.