### PR TITLE
If the workspace folder is a symlink, convert paths relative to it

### DIFF
--- a/src/config.hh
+++ b/src/config.hh
@@ -32,7 +32,7 @@ initialization options specified by the client. For example, in shell syntax:
 struct Config {
   // **Not available for configuration**
   std::string fallbackFolder;
-  std::vector<std::string> workspaceFolders;
+  std::vector<std::pair<std::string, std::string>> workspaceFolders;
   // If specified, this option overrides compile_commands.json and this
   // external command will be executed with an option |projectRoot|.
   // The initialization options will be provided as stdin.

--- a/src/lsp.cc
+++ b/src/lsp.cc
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include "log.hh"
 
+#include <llvm/ADT/StringRef.h>
+
 #include <rapidjson/document.h>
 
 #include <algorithm>
@@ -131,6 +133,10 @@ std::string DocumentUri::GetPath() const {
     ret[0] = toupper(ret[0]);
   }
 #endif
+  if (g_config)
+    for (auto &[root, real] : g_config->workspaceFolders)
+      if (real.size() && llvm::StringRef(ret).startswith(real))
+        return root + ret.substr(real.size());
   return ret;
 }
 

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -337,19 +337,35 @@ void Initialize(MessageHandler *m, InitializeParam &param, ReplyOnce &reply) {
   // Set project root.
   EnsureEndsInSlash(project_path);
   g_config->fallbackFolder = project_path;
+  auto &workspaceFolders = g_config->workspaceFolders;
+  auto Real = [](const std::string &path) {
+    SmallString<256> real;
+    sys::fs::real_path(path, real);
+    return sys::path::convert_to_slash(real) + '/';
+  };
   for (const WorkspaceFolder &wf : param.workspaceFolders) {
     std::string path = wf.uri.GetPath();
     EnsureEndsInSlash(path);
-    g_config->workspaceFolders.push_back(path);
-    LOG_S(INFO) << "add workspace folder " << wf.name << ": " << path;
+    std::string real = Real(path);
+    workspaceFolders.emplace_back(path, path == real ? "" : real);
   }
-  if (param.workspaceFolders.empty())
-    g_config->workspaceFolders.push_back(project_path);
+  if (workspaceFolders.empty()) {
+    std::string real = Real(project_path);
+    workspaceFolders.emplace_back(project_path,
+                                  project_path == real ? "" : real);
+  }
+  llvm::sort(workspaceFolders,
+             [](auto &l, auto &r) { return l.first.size() > r.first.size(); });
+  for (auto &[folder, real] : workspaceFolders)
+    if (real.empty())
+      LOG_S(INFO) << "workspace folder: " << folder;
+    else
+      LOG_S(INFO) << "workspace folder: " << folder << " -> " << real;
 
   if (g_config->cache.directory.empty())
     g_config->cache.retainInMemory = 1;
   else if (!g_config->cache.hierarchicalPath)
-    for (const std::string &folder : g_config->workspaceFolders) {
+    for (auto &[folder, _] : workspaceFolders) {
       // Create two cache directories for files inside and outside of the
       // project.
       std::string escaped = EscapeFileName(folder.substr(0, folder.size() - 1));
@@ -358,7 +374,7 @@ void Initialize(MessageHandler *m, InitializeParam &param, ReplyOnce &reply) {
     }
 
   idx::Init();
-  for (const std::string &folder : g_config->workspaceFolders)
+  for (auto &[folder, _] : workspaceFolders)
     m->project->Load(folder);
 
   // Start indexer threads. Start this after loading the project, as that

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -145,7 +145,7 @@ std::string AppendSerializationFormat(const std::string &base) {
   }
 }
 
-std::string GetCachePath(const std::string &src) {
+std::string GetCachePath(std::string src) {
   if (g_config->cache.hierarchicalPath) {
     std::string ret =
         g_config->cache.directory + (src[0] == '/' ? src.substr(1) : src);
@@ -154,7 +154,7 @@ std::string GetCachePath(const std::string &src) {
 #endif
     return ret;
   }
-  for (auto &root : g_config->workspaceFolders)
+  for (auto &[root, _] : g_config->workspaceFolders)
     if (StringRef(src).startswith(root)) {
       auto len = root.size();
       return g_config->cache.directory +


### PR DESCRIPTION
* The project root directory may be a symlink. The decision whether the symlink should be followed is on the client side.
  I believe many editors (emacs,vim) follow symlinks => there is no confusing part.

  If the editor doesn't (VSCode), ccls should use `/tmp/symlink/a.cc` as the canonical path, instead of `/tmp/real/a.cc`. In this case, the user had better not to open `/tmp/real/b.cc` directly (I'll call it "unsolicited open"), as t raises the question whether the symlink and the target should be considered the same file. The most sensible approach is probably to convert every `/tmp/real/` path to `/tmp/symlink/`.
* Some files/directories under the root directory are symlinks. If `/tmp/real/a.h -> /tmp/real/b.h` and `/tmp/real/a.cc` includes `a.h`. The clang internals always follow links and think the file is `b.h`. `a.h` and `b.h` have no distinction in clang. I'd like to treat `a.h` and `b.h` as different but it is impossible.