### PR TITLE
Enhance the output of --version with Git describe results.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,3 +209,20 @@ target_sources(ccls PRIVATE
   src/messages/textDocument_signatureHelp.cc
   src/messages/workspace.cc
 )
+
+### Obtain CCLS version information from Git
+### This only happens when cmake is re-run!
+
+if(NOT CCLS_VERSION)
+    execute_process(COMMAND git describe --tag HEAD
+        OUTPUT_VARIABLE CCLS_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+
+    if(NOT CCLS_VERSION)
+        set(CCLS_VERSION "<unknown>")
+    endif()
+endif()
+
+set_property(SOURCE src/main.cc APPEND PROPERTY
+    COMPILE_DEFINITIONS CCLS_VERSION=\"${CCLS_VERSION}\")

--- a/src/main.cc
+++ b/src/main.cc
@@ -68,11 +68,15 @@ void CloseLog() { fclose(ccls::log::file); }
 
 } // namespace
 
+#ifndef CCLS_VERSION
+# define CCLS_VERSION "<unknown>"
+#endif
+
 int main(int argc, char **argv) {
   TraceMe();
   sys::PrintStackTraceOnErrorSignal(argv[0]);
   cl::SetVersionPrinter([](raw_ostream &OS) {
-    OS << clang::getClangToolFullVersion("ccls") << "\n";
+    OS << clang::getClangToolFullVersion("ccls version " CCLS_VERSION " / clang") << "\n";
   });
 
   for (auto &I : TopLevelSubCommand->OptionsMap)


### PR DESCRIPTION
Implement a solution to issue #334.  This also allows `-DCCLS_VERSION` to be provided via the `cmake` command line, for upstream facilities that want to set the version during the build without having access to the Git repository.

Note that this only obtains a new version when you run cmake, so if you do a `git pull` it will no longer have the correct version unless you rerun `cmake`.  I'm trying to create an implementation which always checks but only rebuilds if something changes; unfortunately it's very tricky to do this in CMake (I could do it in 5 seconds in make :smile:)