### PR TITLE
Set RetainRemappedFileBuffers to true

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1256,6 +1256,7 @@ Index(SemaManager *manager, WorkingFiles *wfiles, VFS *vfs,
       Clang->getDiagnostics(), Clang->getInvocation().TargetOpts));
   if (!Clang->hasTarget())
     return {};
+  Clang->getPreprocessorOpts().RetainRemappedFileBuffers = true;
 #if LLVM_VERSION_MAJOR >= 9 // rC357037
   Clang->createFileManager(FS);
 #else
@@ -1302,8 +1303,6 @@ Index(SemaManager *manager, WorkingFiles *wfiles, VFS *vfs,
     LOG_S(ERROR) << "failed to index " << main;
     return {};
   }
-  for (auto &Buf : Bufs)
-    Buf.release();
 
   std::vector<std::unique_ptr<IndexFile>> result;
   for (auto &it : param.UID2File) {

--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -313,6 +313,7 @@ std::unique_ptr<CompilerInstance> BuildCompilerInstance(
       Clang->getDiagnostics(), Clang->getInvocation().TargetOpts));
   if (!Clang->hasTarget())
     return nullptr;
+  Clang->getPreprocessorOpts().RetainRemappedFileBuffers = true;
   // Construct SourceManager with UserFilesAreVolatile: true because otherwise
   // RequiresNullTerminator: true may cause out-of-bounds read when a file is
   // mmap'ed but is saved concurrently.
@@ -493,7 +494,6 @@ void *CompletionMain(void *manager_) {
     Clang->setCodeCompletionConsumer(task->Consumer.release());
     if (!Parse(*Clang))
       continue;
-    Buf.release();
 
     task->on_complete(&Clang->getCodeCompletionConsumer());
   }
@@ -583,7 +583,6 @@ void *DiagnosticMain(void *manager_) {
       continue;
     if (!Parse(*Clang))
       continue;
-    Buf.release();
 
     auto Fill = [](const DiagBase &d, Diagnostic &ret) {
       ret.range = lsRange{{d.range.start.line, d.range.start.column},


### PR DESCRIPTION
Reported by David Welch in #350.

This fixes double-free of llvm::MemoryBuffer when parsing fails.