### PR TITLE
[WIP] Preliminary CUDA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Telegram](https://img.shields.io/badge/telegram-@cclsp-blue.svg)](https://telegram.me/cclsp)
 [![Gitter](https://img.shields.io/badge/gitter-ccls--project-blue.svg?logo=gitter-white)](https://gitter.im/ccls-project/ccls)
 
-ccls, which originates from [cquery](https://github.com/cquery-project/cquery), is a C/C++/Objective-C language server.
+This is a temporary fork of ccls with experimental CUDA support. `ccls` originates from [cquery](https://github.com/cquery-project/cquery), is a C/C++/Objective-C language server.
 
   * code completion (with both signature help and snippets)
   * [definition](src/messages/textDocument_definition.cc)/[references](src/messages/textDocument_references.cc), and other cross references
@@ -16,6 +16,26 @@ ccls, which originates from [cquery](https://github.com/cquery-project/cquery), 
   * diagnostics and code actions (clang FixIts)
   * semantic highlighting and preprocessor skipped regions
   * semantic navigation: `$ccls/navigate`
+
+## CUDA quickstart
+
+Your `.ccls` configuration should look something like:
+```
+%compile_commands.json
+%cu --cuda-gpu-arch=sm_70
+%cu --cuda-path=/usr/local/cuda-9.2/
+```
+This fork changes the compile commands from the `compile_commands.json` file that look like:
+
+    /usr/local/cuda/bin/nvcc -ccbin=gcc-6  -I../src -I../external/cutlass -I../external/cub -isystem=../external/googletest/googletest/include   -Xcompiler -fopenmp --expt-extended-lambda --std=c++11 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_70,code=compute_70 -g   -x cu -c /home/max/dev/cuml/ml-prims/test/add.cu -o test/CMakeFiles/mlcommon_test.dir/add.cu.o && /usr/local/cuda/bin/nvcc -ccbin=gcc-6  -I../src -I../external/cutlass -I../external/cub -isystem=../external/googletest/googletest/include   -Xcompiler -fopenmp --expt-extended-lambda --std=c++11 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_70,code=compute_70 -g   -x cu -M /home/max/dev/cuml/ml-prims/test/add.cu -MT test/CMakeFiles/mlcommon_test.dir/add.cu.o -o $DEP_FILE
+
+To something more like:
+
+    clang -I../src -I../external/cutlass -I../external/cub -isystem=../external/googletest/googletest/include --std=c++11 --cuda-gpu-arch=sm_70 --cuda-path=/usr/local/cuda-9.2/ -c add.cu
+
+In other words, it whitelists includes (`-I`) and c++ standard flags, but ignores all the `nvcc` switches that `clang` doesn't understand. Note that clang understands CUDA files by default.
+
+## General Info
 
 It has a global view of the code base and support a lot of cross reference features, see [wiki/FAQ](../../wiki/FAQ).
 It starts indexing the whole project (including subprojects if exist) parallelly when you open the first file, while the main thread can serve requests before the indexing is complete.

--- a/src/lsp.hh
+++ b/src/lsp.hh
@@ -261,6 +261,6 @@ struct ShowMessageParam {
 // Used to identify the language at a file level. The ordering is important, as
 // a file previously identified as `C`, will be changed to `Cpp` if it
 // encounters a c++ declaration.
-enum class LanguageId { Unknown = -1, C = 0, Cpp = 1, ObjC = 2, ObjCpp = 3 };
+  enum class LanguageId { Unknown = -1, C = 0, Cpp = 1, ObjC = 2, ObjCpp = 3, CUDA = 4 };
 
 } // namespace ccls


### PR DESCRIPTION
This PR adds support for CUDA files.

The way CMake compiles cuda files happens in a way that makes it hard for `ccls` to parse the command and extract the relevant flags to make `clang` work correctly. I've added a few changes to `ccls` to add explicit CUDA support in both the file detection and `.ccls` configuration to make basic things like code completion and jump-to-definition mostly work.

The nvcc command looks like this (notice two step command)
```
/usr/local/cuda/bin/nvcc -ccbin=gcc-6  -I../src -I../external/cutlass -I../external/cub -isystem=../external/googletest/googletest/include   -Xcompiler -fopenmp --expt-extended-lambda --std=c++11 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_70,code=compute_70 -g   -x cu -c /home/max/dev/cuml/ml-prims/test/add.cu -o test/CMakeFiles/mlcommon_test.dir/add.cu.o && /usr/local/cuda/bin/nvcc -ccbin=gcc-6  -I../src -I../external/cutlass -I../external/cub -isystem=../external/googletest/googletest/include   -Xcompiler -fopenmp --expt-extended-lambda --std=c++11 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_70,code=compute_70 -g   -x cu -M /home/max/dev/cuml/ml-prims/test/add.cu -MT test/CMakeFiles/mlcommon_test.dir/add.cu.o -o $DEP_FILE
```
A similar clang command should look something like this:
```
clang -I../src -I../external/cutlass -I../external/cub -isystem=../external/googletest/googletest/include --std=c++11 --cuda-gpu-arch=sm_70 --cuda-path=/usr/local/cuda-9.2/ -c add.cu
```

I wanted this for myself and my work, but I know there are others who would like this as well. I wanted to make sure to contribute back, given how much I've been using `ccls` in the last year. Most of the additions are pretty simple, but the changes I made at `project.cc:437` feel a bit hacky, and I wanted your feedback to streamline them into something better, if that is possible. Basically I implemented a whitelist which only allows (`-I, -isystem, -std=`) type flags. This basically works, but maybe you have a better idea.

Additionally it requires the user to make their `.ccls` look something like:
```
%compile_commands.json
%cu --cuda-gpu-arch=sm_70
%cu --cuda-path=/usr/local/cuda-9.2/
```
The `--cuda-gpu-arch=sm_70` and `--cuda-path=/usr/local/cuda-9.2/` could possibly be added automatically.

Anyway, thanks for `ccls` and I look forward to your feedback.