### PR TITLE
Fix nested .ccls

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -273,7 +273,7 @@ void LoadDirectoryListing(ProjectProcessor &proc, const std::string &root,
                          files.push_back(path);
                      } else if (sys::path::filename(path) == ".ccls") {
                        std::vector<const char *> args = ReadCompilerArgumentsFromFile(path);
-                       folder.dot_ccls.emplace(sys::path::parent_path(path),
+                       folder.dot_ccls.emplace(sys::path::parent_path(path).str() + '/',
                                                args);
                        std::string l;
                        for (size_t i = 0; i < args.size(); i++) {


### PR DESCRIPTION
In short, nested .ccls is broken in current HEAD. There are 2 issues:

1. At https://github.com/MaskRay/ccls/blob/e496d4e5db47b602b14fe53bd556f11d0b025f52/src/project.cc#L499 file paths are compared with folder path using startswith, consider the following case:

There are 3 `.ccls`:
1. `/a/b/root/.ccls` (folder: `/a/b/root`)
2. `/a/b/root/1/.ccls` (folder: `/a/b/root/1`)
3. `/a/b/root/11/.ccls` (folder: `/a/b/root/11`)

For file `/a/b/root/11/a.cc`, it matches all of these, which one will be used depends on the iterating order of `std::unordered_map`, i.e. pretty much random.

2. At
https://github.com/MaskRay/ccls/blob/e496d4e5db47b602b14fe53bd556f11d0b025f52/src/project.cc#L276
paths returned by `sys::path::parent_path` does not have trailing slashes, however project root used at https://github.com/MaskRay/ccls/blob/e496d4e5db47b602b14fe53bd556f11d0b025f52/src/project.cc#L265 does have (see https://github.com/MaskRay/ccls/blob/e496d4e5db47b602b14fe53bd556f11d0b025f52/src/project.cc#L455), which leads to a dummy `folder.dot_ccls` entry being inserted.

The logic in `FindEntry` is quite complicated, I don't think I understand the original problem here, so feel free to suggest better fixes.