### PR TITLE
Avoid pessimizing moves in threaded_queue.hh

### DIFF
--- a/src/threaded_queue.hh
+++ b/src/threaded_queue.hh
@@ -147,7 +147,7 @@ public:
       auto val = std::move(q->front());
       q->pop_front();
       --total_count_;
-      return std::move(val);
+      return val;
     };
     if (!priority_.empty())
       return execute(&priority_);
@@ -162,7 +162,7 @@ public:
       auto val = std::move(q->front());
       q->pop_front();
       --total_count_;
-      return std::move(val);
+      return val;
     };
     if (priority_.size())
       return execute(&priority_);


### PR DESCRIPTION
Clang produces warnings during compilation:

ccls/src/threaded_queue.hh:150:27: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
ccls/src/threaded_queue.hh:150:27: note: remove ‘std::move’ call

This patch fixes the issue.