### PR TITLE
Don't add include paths as SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,8 +144,7 @@ set_property(SOURCE src/utils.cc APPEND PROPERTY COMPILE_DEFINITIONS
 ### Includes
 
 target_include_directories(ccls PRIVATE src)
-target_include_directories(ccls SYSTEM PRIVATE
-  third_party ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
+target_include_directories(ccls SYSTEM PRIVATE third_party)
 
 if(USE_SYSTEM_RAPIDJSON)
   find_package(RapidJSON QUIET)
@@ -153,7 +152,33 @@ endif()
 if(NOT RapidJSON_FOUND)
   set(RapidJSON_INCLUDE_DIRS third_party/rapidjson/include)
 endif()
-target_include_directories(ccls SYSTEM PRIVATE ${RapidJSON_INCLUDE_DIRS})
+
+# only add the include directories for LLVM, clang & rapidjson if they aren't in
+# the default list of include directories (these are stored by cmake in
+# CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+#
+# Adding the same include directory twice with SYSTEM results these being
+# included as -isystem, which causes issues with libstdc++ from gcc9 with their
+# usage of #include_next<>
+# see also: https://github.com/MaskRay/ccls/pull/417
+foreach(include_dir
+    ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS} ${RapidJSON_INCLUDE_DIRS})
+
+  # rapidjson's include dir is a relative path => normalize it
+  get_filename_component(include_dir_realpath ${include_dir} REALPATH)
+  set(dir_already_included FALSE)
+
+  foreach(cxx_include_dir ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+    if("${cxx_include_dir}" STREQUAL "${include_dir_realpath}")
+      set(dir_already_included TRUE)
+    endif()
+  endforeach()
+
+  if(NOT "${dir_already_included}")
+    target_include_directories(ccls SYSTEM PRIVATE ${include_dir})
+  endif()
+endforeach()
+
 
 ### Install
 


### PR DESCRIPTION
With the introduction of gcc 9 my builds of ccls on openSUSE Tumbleweed started failing on ppc, arm and SystemZ with odd error messages like the following:
```
[   58s] [ 11%] Building CXX object CMakeFiles/ccls.dir/src/fuzzy_match.cc.o
[   58s] /usr/bin/c++   -I/home/abuild/rpmbuild/BUILD/ccls-0.20190314/src -isystem /home/abuild/rpmbuild/BUILD/ccls-0.20190314/third_party -isystem /usr/lib64/cmake/RapidJSON/../../../include  -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -DNDEBUG -O2 -g -DNDEBUG   -Wall -Wno-sign-compare -Wno-return-type -Wno-unused-result -fno-rtti -pthread -std=c++17 -o CMakeFiles/ccls.dir/src/fuzzy_match.cc.o -c /home/abuild/rpmbuild/BUILD/ccls-0.20190314/src/fuzzy_match.cc
[   58s] In file included from /usr/include/c++/9/ext/string_conversions.h:41,
[   58s]                  from /usr/include/c++/9/bits/basic_string.h:6493,
[   58s]                  from /usr/include/c++/9/string:55,
[   58s]                  from /home/abuild/rpmbuild/BUILD/ccls-0.20190314/src/fuzzy_match.hh:19,
[   58s]                  from /home/abuild/rpmbuild/BUILD/ccls-0.20190314/src/fuzzy_match.cc:16:
[   58s] /usr/include/c++/9/cstdlib:75:15: fatal error: stdlib.h: No such file or directory
[   58s]    75 | #include_next <stdlib.h>
[   58s]       |               ^~~~~~~~~~
[   58s] compilation terminated.
```

I've tracked this down to being caused by the usage of `-isystem` for the include paths instead of `-I`.

This pull request removes the flag `SYSTEM` from the `target_include_directories()` calls, which fixes the compilation problems.