### PR TITLE
Use realpath(3) to canonicalize file paths on POSIX systems

### DIFF
--- a/src/platform_posix.cc
+++ b/src/platform_posix.cc
@@ -39,9 +39,6 @@ limitations under the License.
 #include <malloc.h>
 #endif
 
-#include <llvm/ADT/SmallString.h>
-#include <llvm/Support/Path.h>
-
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
@@ -52,10 +49,14 @@ namespace pipeline {
 void ThreadEnter();
 }
 
+// Normalize the path, including eliminating redundant . and duplicated /
+// characters.
 std::string NormalizePath(const std::string &path) {
-  llvm::SmallString<256> P(path);
-  llvm::sys::path::remove_dots(P, true);
-  return {P.data(), P.size()};
+  char canonical[PATH_MAX + 1];
+  if (realpath(path.c_str(), canonical)) {
+    return canonical;
+  }
+  return path;
 }
 
 void FreeUnusedMemory() {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -125,6 +125,7 @@ void EnsureEndsInSlash(std::string &path) {
 
 std::string EscapeFileName(std::string path) {
   bool slash = path.size() && path.back() == '/';
+  path = NormalizePath(path);
 #ifdef _WIN32
   std::replace(path.begin(), path.end(), ':', '@');
 #endif


### PR DESCRIPTION
This is my proposed fix for #418. It's not fancy, but:
 * It's portable (`realpath(3)` is required by POSIX)
 * It's correct
 * It doesn't rely on bleeding edge C++17 `std::filesystem` stuff that's not yet ready in GCC/Clang
 * It works on paths longer than 256 characters 🤣