### PR TITLE
Use volatile filesystem on Windows

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1264,6 +1264,12 @@ Index(SemaManager *manager, WorkingFiles *wfiles, VFS *vfs,
   Clang->createFileManager();
 #endif
 
+#ifdef _WIN32
+  // Always set UserFilesAreVolatile true to avoid write locks on Windows
+  Clang->setSourceManager(new SourceManager(Clang->getDiagnostics(),
+                                            Clang->getFileManager(), true));
+#endif
+
   IndexParam param(*vfs, no_linkage);
   auto DataConsumer = std::make_shared<IndexDataConsumer>(param);
 


### PR DESCRIPTION
When Clang loads up the files required for indexing it memory maps any source files over a specific threshold. This is fine for Unix, but the strict file locking policies on Windows cause issues especially when an IDE saves the file and triggers a `textDocument/didSave`. If the file is re-saved before the previous indexing has complete, the save will fail and often produce various ambiguous errors.

I have been using this for a month and I believe clangd has something very similar implemented. No issues so far, even on very large source files, so I want to merge if possible.