### PR TITLE
Fix some clang-tidy performance warnings

### DIFF
--- a/src/lsp.cc
+++ b/src/lsp.cc
@@ -63,7 +63,7 @@ void DocumentUri::setPath(const std::string &path) {
   // file:///c%3A/Users/jacob/Desktop/superindex/indexer/full_tests
   raw_uri = path;
 
-  size_t index = raw_uri.find(":");
+  size_t index = raw_uri.find(':');
   if (index == 1) { // widows drive letters must always be 1 char
     raw_uri.replace(raw_uri.begin() + index, raw_uri.begin() + index + 1,
                     "%3A");

--- a/src/message_handler.cc
+++ b/src/message_handler.cc
@@ -121,9 +121,8 @@ void ReplyOnce::replyLocationLink(std::vector<LocationLink> &result) {
   if (g_config->client.linkSupport) {
     (*this)(result);
   } else {
-    std::vector<Location> result1;
-    for (auto &loc : result)
-      result1.emplace_back(std::move(loc));
+    std::vector<Location> result1{std::make_move_iterator(result.begin()),
+                                  std::make_move_iterator(result.end())};
     (*this)(result1);
   }
 }

--- a/src/message_handler.cc
+++ b/src/message_handler.cc
@@ -121,8 +121,8 @@ void ReplyOnce::replyLocationLink(std::vector<LocationLink> &result) {
   if (g_config->client.linkSupport) {
     (*this)(result);
   } else {
-    std::vector<Location> result1{std::make_move_iterator(result.begin()),
-                                  std::make_move_iterator(result.end())};
+    std::vector<Location> result1(std::make_move_iterator(result.begin()),
+                                  std::make_move_iterator(result.end()));
     (*this)(result1);
   }
 }

--- a/src/message_handler.hh
+++ b/src/message_handler.hh
@@ -32,8 +32,9 @@ struct WorkingFile;
 struct WorkingFiles;
 
 namespace pipeline {
-void reply(RequestId id, const std::function<void(JsonWriter &)> &fn);
-void replyError(RequestId id, const std::function<void(JsonWriter &)> &fn);
+void reply(const RequestId &id, const std::function<void(JsonWriter &)> &fn);
+void replyError(const RequestId &id,
+                const std::function<void(JsonWriter &)> &fn);
 } // namespace pipeline
 
 struct CodeActionParam {

--- a/src/messages/workspace.cc
+++ b/src/messages/workspace.cc
@@ -101,7 +101,7 @@ void MessageHandler::workspace_didChangeWorkspaceFolders(
     if (folder == real)
       real.clear();
     LOG_S(INFO) << "add workspace folder " << wf.name << ": "
-                << (real.empty() ? folder : folder + " -> " + real);
+                << (real.empty() ? folder : (folder + " -> ").append(real));
     workspaceFolders.emplace_back();
     auto it = workspaceFolders.end() - 1;
     for (; it != workspaceFolders.begin() && folder < it[-1].first; --it)

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -616,7 +616,7 @@ void mainLoop() {
 
   SemaManager manager(
       &project, &wfiles,
-      [&](const std::string &path, std::vector<Diagnostic> diagnostics) {
+      [](const std::string &path, std::vector<Diagnostic> diagnostics) {
         PublishDiagnosticParam params;
         params.uri = DocumentUri::fromPath(path);
         params.diagnostics = std::move(diagnostics);
@@ -718,7 +718,7 @@ void standalone(const std::string &root) {
   VFS vfs;
   SemaManager manager(
       nullptr, nullptr,
-      [&](const std::string &, const std::vector<Diagnostic> &) {},
+      [](const std::string &, const std::vector<Diagnostic> &) {},
       [](const RequestId &id) {});
   IncludeComplete complete(&project);
 

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -616,13 +616,13 @@ void mainLoop() {
 
   SemaManager manager(
       &project, &wfiles,
-      [&](std::string path, std::vector<Diagnostic> diagnostics) {
+      [&](const std::string &path, std::vector<Diagnostic> diagnostics) {
         PublishDiagnosticParam params;
         params.uri = DocumentUri::fromPath(path);
-        params.diagnostics = diagnostics;
+        params.diagnostics = std::move(diagnostics);
         notify("textDocument/publishDiagnostics", params);
       },
-      [](RequestId id) {
+      [](const RequestId &id) {
         if (id.valid()) {
           ResponseError err;
           err.code = ErrorCode::InternalError;
@@ -717,8 +717,9 @@ void standalone(const std::string &root) {
   WorkingFiles wfiles;
   VFS vfs;
   SemaManager manager(
-      nullptr, nullptr, [&](std::string, std::vector<Diagnostic>) {},
-      [](RequestId id) {});
+      nullptr, nullptr,
+      [&](const std::string &, const std::vector<Diagnostic> &) {},
+      [](const RequestId &id) {});
   IncludeComplete complete(&project);
 
   MessageHandler handler;
@@ -756,7 +757,7 @@ void standalone(const std::string &root) {
 void index(const std::string &path, const std::vector<const char *> &args,
            IndexMode mode, bool must_exist, RequestId id) {
   pending_index_requests++;
-  index_request->pushBack({path, args, mode, must_exist, id},
+  index_request->pushBack({path, args, mode, must_exist, std::move(id)},
                           mode != IndexMode::Background);
 }
 
@@ -800,7 +801,7 @@ void notifyOrRequest(const char *method, bool request,
   for_stdout->pushBack(output.GetString());
 }
 
-static void reply(RequestId id, const char *key,
+static void reply(const RequestId &id, const char *key,
                   const std::function<void(JsonWriter &)> &fn) {
   rapidjson::StringBuffer output;
   rapidjson::Writer<rapidjson::StringBuffer> w(output);
@@ -828,11 +829,12 @@ static void reply(RequestId id, const char *key,
   for_stdout->pushBack(output.GetString());
 }
 
-void reply(RequestId id, const std::function<void(JsonWriter &)> &fn) {
+void reply(const RequestId &id, const std::function<void(JsonWriter &)> &fn) {
   reply(id, "result", fn);
 }
 
-void replyError(RequestId id, const std::function<void(JsonWriter &)> &fn) {
+void replyError(const RequestId &id,
+                const std::function<void(JsonWriter &)> &fn) {
   reply(id, "error", fn);
 }
 } // namespace pipeline

--- a/src/pipeline.hh
+++ b/src/pipeline.hh
@@ -65,10 +65,11 @@ template <typename T> void request(const char *method, T &result) {
   notifyOrRequest(method, true, [&](JsonWriter &w) { reflect(w, result); });
 }
 
-void reply(RequestId id, const std::function<void(JsonWriter &)> &fn);
+void reply(const RequestId &id, const std::function<void(JsonWriter &)> &fn);
 
-void replyError(RequestId id, const std::function<void(JsonWriter &)> &fn);
-template <typename T> void replyError(RequestId id, T &result) {
+void replyError(const RequestId &id,
+                const std::function<void(JsonWriter &)> &fn);
+template <typename T> void replyError(const RequestId &id, T &result) {
   replyError(id, [&](JsonWriter &w) { reflect(w, result); });
 }
 } // namespace pipeline

--- a/src/project.cc
+++ b/src/project.cc
@@ -249,7 +249,7 @@ bool appendToCDB(const std::vector<const char *> &args) {
   return args.size() && StringRef("%compile_commands.json") == args[0];
 }
 
-std::vector<const char *> getFallback(const std::string path) {
+std::vector<const char *> getFallback(const std::string &path) {
   std::vector<const char *> argv{"clang"};
   if (sys::path::extension(path) == ".h")
     argv.push_back("-xobjective-c++-header");
@@ -607,7 +607,7 @@ Project::Entry Project::findEntry(const std::string &path, bool can_redirect,
   return ret;
 }
 
-void Project::index(WorkingFiles *wfiles, RequestId id) {
+void Project::index(WorkingFiles *wfiles, const RequestId &id) {
   auto &gi = g_config->index;
   GroupMatch match(gi.whitelist, gi.blacklist),
       match_i(gi.initialWhitelist, gi.initialBlacklist);

--- a/src/project.hh
+++ b/src/project.hh
@@ -76,7 +76,7 @@ struct Project {
   void setArgsForFile(const std::vector<const char *> &args,
                       const std::string &path);
 
-  void index(WorkingFiles *wfiles, RequestId id);
+  void index(WorkingFiles *wfiles, const RequestId &id);
   void indexRelated(const std::string &path);
 };
 } // namespace ccls

--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -231,7 +231,7 @@ class StoreDiags : public DiagnosticConsumer {
   }
 
 public:
-  StoreDiags(std::string path) : path(path) {}
+  StoreDiags(std::string path) : path{std::move(path)} {}
   std::vector<Diag> take() { return std::move(output); }
   bool isConcerned(const SourceManager &sm, SourceLocation l) {
     FileID fid = sm.getFileID(l);
@@ -683,8 +683,10 @@ std::shared_ptr<PreambleData> Session::getPreamble() {
 
 SemaManager::SemaManager(Project *project, WorkingFiles *wfiles,
                          OnDiagnostic on_diagnostic, OnDropped on_dropped)
-    : project_(project), wfiles(wfiles), on_diagnostic_(on_diagnostic),
-      on_dropped_(on_dropped), pch(std::make_shared<PCHContainerOperations>()) {
+    : project_(project), wfiles(wfiles),
+      on_diagnostic_(std::move(on_diagnostic)),
+      on_dropped_(std::move(on_dropped)),
+      pch(std::make_shared<PCHContainerOperations>()) {
   spawnThread(ccls::preambleMain, this);
   spawnThread(ccls::completionMain, this);
   spawnThread(ccls::diagnosticMain, this);

--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -231,7 +231,7 @@ class StoreDiags : public DiagnosticConsumer {
   }
 
 public:
-  StoreDiags(std::string path) : path{std::move(path)} {}
+  StoreDiags(std::string path) : path(std::move(path)) {}
   std::vector<Diag> take() { return std::move(output); }
   bool isConcerned(const SourceManager &sm, SourceLocation l) {
     FileID fid = sm.getFileID(l);

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -35,7 +35,7 @@ bool gTestOutputMode = false;
 
 namespace ccls {
 
-void JsonReader::iterArray(const llvm::function_ref<void()> fn) {
+void JsonReader::iterArray(llvm::function_ref<void()> fn) {
   if (!m->IsArray())
     throw std::invalid_argument("array");
   // Use "0" to indicate any element for now.
@@ -48,7 +48,7 @@ void JsonReader::iterArray(const llvm::function_ref<void()> fn) {
   }
   path_.pop_back();
 }
-void JsonReader::member(const char *name, const llvm::function_ref<void()> fn) {
+void JsonReader::member(const char *name, llvm::function_ref<void()> fn) {
   path_.push_back(name);
   auto it = m->FindMember(name);
   if (it != m->MemberEnd()) {

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -35,7 +35,7 @@ bool gTestOutputMode = false;
 
 namespace ccls {
 
-void JsonReader::iterArray(std::function<void()> fn) {
+void JsonReader::iterArray(const llvm::function_ref<void()> fn) {
   if (!m->IsArray())
     throw std::invalid_argument("array");
   // Use "0" to indicate any element for now.
@@ -48,7 +48,7 @@ void JsonReader::iterArray(std::function<void()> fn) {
   }
   path_.pop_back();
 }
-void JsonReader::member(const char *name, std::function<void()> fn) {
+void JsonReader::member(const char *name, const llvm::function_ref<void()> fn) {
   path_.push_back(name);
   auto it = m->FindMember(name);
   if (it != m->MemberEnd()) {

--- a/src/serializer.hh
+++ b/src/serializer.hh
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "utils.hh"
 
+#include <llvm/ADT/STLExtras.h>
 #include <llvm/Support/Compiler.h>
 
 #include <macro_map.h>
@@ -48,8 +49,8 @@ struct JsonReader {
   JsonReader(rapidjson::Value *m) : m(m) {}
   void startObject() {}
   void endObject() {}
-  void iterArray(std::function<void()> fn);
-  void member(const char *name, std::function<void()> fn);
+  void iterArray(const llvm::function_ref<void()> fn);
+  void member(const char *name, const llvm::function_ref<void()> fn);
   bool isNull();
   std::string getString();
   std::string getPath() const;

--- a/src/serializer.hh
+++ b/src/serializer.hh
@@ -49,8 +49,8 @@ struct JsonReader {
   JsonReader(rapidjson::Value *m) : m(m) {}
   void startObject() {}
   void endObject() {}
-  void iterArray(const llvm::function_ref<void()> fn);
-  void member(const char *name, const llvm::function_ref<void()> fn);
+  void iterArray(llvm::function_ref<void()> fn);
+  void member(const char *name, llvm::function_ref<void()> fn);
   bool isNull();
   std::string getString();
   std::string getPath() const;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -152,7 +152,7 @@ std::string realPath(const std::string &path) {
 bool normalizeFolder(std::string &path) {
   for (auto &[root, real] : g_config->workspaceFolders)
     if (real.size() && llvm::StringRef(path).startswith(real)) {
-      path = root + path.substr(real.size());
+      path = root.append(path.substr(real.size()));
       return true;
     }
   return false;


### PR DESCRIPTION
Hello,
I run some clang-tidy performance-* checks on the code and decided to correct the warnings. Most of them warn about unnecessary copy or to preallocate a vector.

It seems that clang-format-8 added some additional unintended changes.

Cheers.