### PR TITLE
Fix builds for LLVM 9 (for LLVM build without BUILD_SHARED_LIBS=ON)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,23 +68,33 @@ endif()
 
 ### Libraries
 
+# LLVM >= 9 ships the C++ libraries by default in a single library libclang-cpp,
+# but this is not universally enabled on all distributions.
+# If clang-cpp is available, then link against it, otherwise link against the
+# individual clang libraries.
 find_package(Clang REQUIRED)
 
-target_link_libraries(ccls PRIVATE
-  clangIndex
-  clangFormat
-  clangTooling
-  clangToolingInclusions
-  clangToolingCore
-  clangFrontend
-  clangParse
-  clangSerialization
-  clangSema
-  clangAST
-  clangLex
-  clangDriver
-  clangBasic
-)
+if(TARGET clang-cpp AND NOT TARGET clangBasic)
+  target_link_libraries(ccls PRIVATE
+    clang-cpp
+    )
+else()
+  target_link_libraries(ccls PRIVATE
+    clangIndex
+    clangFormat
+    clangTooling
+    clangToolingInclusions
+    clangToolingCore
+    clangFrontend
+    clangParse
+    clangSerialization
+    clangSema
+    clangAST
+    clangLex
+    clangDriver
+    clangBasic
+    )
+endif()
 
 if(LLVM_LINK_LLVM_DYLIB)
   target_link_libraries(ccls PRIVATE LLVM)


### PR DESCRIPTION
LLVM 9 officially ships the C++ libraries as a single library `libclang-cpp.so`. This makes ccls fail to link as the individual libraries `libclangIndex.so`, `libclangFormat.so`, etc. are no longer present.

We instead try to find the clang-cpp library and if it is found we link against it instead of the individual libraries. If it is not found, then we proceed as previously.