### PR TITLE
cmake: support CLANG_LINK_CLANG_DYLIB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,21 +70,25 @@ endif()
 
 find_package(Clang REQUIRED)
 
-target_link_libraries(ccls PRIVATE
-  clangIndex
-  clangFormat
-  clangTooling
-  clangToolingInclusions
-  clangToolingCore
-  clangFrontend
-  clangParse
-  clangSerialization
-  clangSema
-  clangAST
-  clangLex
-  clangDriver
-  clangBasic
-)
+if(CLANG_LINK_CLANG_DYLIB)
+  target_link_libraries(ccls PRIVATE clang-cpp)
+else()
+  target_link_libraries(ccls PRIVATE
+    clangIndex
+    clangFormat
+    clangTooling
+    clangToolingInclusions
+    clangToolingCore
+    clangFrontend
+    clangParse
+    clangSerialization
+    clangSema
+    clangAST
+    clangLex
+    clangDriver
+    clangBasic
+  )
+endif()
 
 if(LLVM_LINK_LLVM_DYLIB)
   target_link_libraries(ccls PRIVATE LLVM)


### PR DESCRIPTION
------------

Prebuilt binaries downloaded from http://releases.llvm.org/9.0.0/

Link against `libLLVM*.a libclang*.a`
`cmake -GNinja -H. -BBundled9C -DCMAKE_PREFIX_PATH=$PWD/build/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04`

```
% stat -c %s Bundled9/ccls
32432992
```

Link against `libLLVM*.a libclang-cpp.so`
`cmake -GNinja -H. -BBundled9C -DCMAKE_PREFIX_PATH=$PWD/build/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04 -DCLANG_LINK_CLANG_DYLIB=on`

```
% stat -c %s Bundled9C/ccls
1774992
```