### PR TITLE
Improve completion cache.

### DIFF
--- a/src/sema_manager.hh
+++ b/src/sema_manager.hh
@@ -176,7 +176,7 @@ template <typename T> struct CompleteConsumerCache {
                     Position position) {
     std::lock_guard lock(mutex);
     return this->path == path && this->position == position &&
-           this->line == line;
+            line.substr(0,position.character) == this->line.substr(0, position.character);
   }
 };
 } // namespace ccls

--- a/src/sema_manager.hh
+++ b/src/sema_manager.hh
@@ -159,8 +159,8 @@ struct SemaManager {
 };
 
 // Cached completion information, so we can give fast completion results when
-// the user erases a character. vscode will resend the completion request if
-// that happens.
+// the user adds or erases a character. vscode will resend the completion request
+// if that happens.
 template <typename T> struct CompleteConsumerCache {
   std::mutex mutex;
   std::string path;


### PR DESCRIPTION
Unfortunately, this change https://github.com/MaskRay/ccls/commit/1a41d2dbd18b6548383b625b960b9178acdb144d made auto-completion for my large projects completely unusable.

My scenario is as follows.

Suppose I have a class variable c, and I want to type c->some_method.
When I type c->, I wait 0.5-1 second until some_method appears. (my idle-delay is set to 0, but it doesn't really matter).

Then, when I type o (the next character), emacs freezes and for 0.5 -1 seconds before it generates new completions request. This happens because it no longer uses the cache and the completions are recomputed again.  
This is super inconvenient! Previously, we used to reuse the cache for position c-> and filter it out when the new characters are added.

As far as I understand, my change should fix the bug which the original commit was supposed to fix, and will satisfy the important use case I desribed above (I verified the latter). But I may be misunderstanding the code, let me know.