### PR TITLE
initialize: Implement serverInfo (3.15.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,3 +240,5 @@ endif()
 
 set_property(SOURCE src/main.cc APPEND PROPERTY
              COMPILE_DEFINITIONS CCLS_VERSION=\"${CCLS_VERSION}\")
+set_property(SOURCE src/messages/initialize.cc APPEND PROPERTY
+             COMPILE_DEFINITIONS CCLS_VERSION=\"${CCLS_VERSION}\")

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -221,8 +221,13 @@ REFLECT_STRUCT(InitializeParam, rootUri, capabilities, trace, workspaceFolders);
 
 struct InitializeResult {
   ServerCap capabilities;
+  struct ServerInfo {
+    const char *name = "ccls";
+    const char *version = CCLS_VERSION;
+  } serverInfo;
 };
-REFLECT_STRUCT(InitializeResult, capabilities);
+REFLECT_STRUCT(InitializeResult::ServerInfo, name, version);
+REFLECT_STRUCT(InitializeResult, capabilities, serverInfo);
 
 struct FileSystemWatcher {
   std::string globPattern = "**/*";


### PR DESCRIPTION
I don't really like the repeated set_property in CMakeList.txt, but wasn't able to find an easy, alternative way to access the version info in initialize.cc.

Thanks.

----

Return serverInfo for an initialize request as the upcoming version of
LSP specifies.  This helps clients to identify ccls even when they
just connect to a TCP port and allows them to easily implement server
specific functionalities like $ccls/navigate.