### PR TITLE
Add name for anonymous Enum

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -874,10 +874,10 @@ public:
                 Usr usr1 = getUsr(d1, &info1);
                 IndexType &type1 = db->toType(usr1);
                 SourceLocation sl1 = d1->getLocation();
-                type1.def.spell = {
-                    Use{{fromTokenRange(sm, lang, {sl1, sl1}), Role::Definition},
-                        lid},
-                    fromTokenRange(sm, lang, sr1)};
+                type1.def.spell = {Use{{fromTokenRange(sm, lang, {sl1, sl1}),
+                                        Role::Definition},
+                                       lid},
+                                   fromTokenRange(sm, lang, sr1)};
                 type1.def.detailed_name = intern(info1->short_name);
                 type1.def.short_name_size = int16_t(info1->short_name.size());
                 type1.def.kind = SymbolKind::TypeParameter;
@@ -943,11 +943,12 @@ public:
             }
       }
       [[fallthrough]];
+    case Decl::Enum:
     case Decl::Record:
-      if (auto *rd = dyn_cast<RecordDecl>(d)) {
+      if (auto *tag_d = dyn_cast<TagDecl>(d)) {
         if (type->def.detailed_name[0] == '\0' && info->short_name.empty()) {
           StringRef tag;
-          switch (rd->getTagKind()) {
+          switch (tag_d->getTagKind()) {
           case TTK_Struct:
             tag = "struct";
             break;
@@ -964,7 +965,7 @@ public:
             tag = "enum";
             break;
           }
-          if (TypedefNameDecl *td = rd->getTypedefNameForAnonDecl()) {
+          if (TypedefNameDecl *td = tag_d->getTypedefNameForAnonDecl()) {
             StringRef name = td->getName();
             std::string detailed = ("anon " + tag + " " + name).str();
             type->def.detailed_name = intern(detailed);
@@ -975,7 +976,7 @@ public:
             type->def.short_name_size = name.size();
           }
         }
-        if (is_def)
+        if (is_def && !isa<EnumDecl>(d))
           if (auto *ord = dyn_cast<RecordDecl>(origD))
             collectRecordMembers(*type, ord);
       }


### PR DESCRIPTION
https://github.com/MaskRay/ccls/blob/bd609e89a29c508c8c763db2ecfad50e207391b3/src/indexer.cc#L963-L965
Here, `case Decl::Record` is trying to match `enum`.  However, `EnumDecl` and `RecordDecl` are both inherited from [`TagDecl`](https://clang.llvm.org/doxygen/classclang_1_1TagDecl.html#details) directly, is, so the matching here will never get executed, which causes the anonymous Enum having no name. So I add a `case:: Enum` matching above `case Decl::Record`, and it will add a simple name for anonymous Enum.  

Of course, removing the matching code is an alternative solution.
Any edits are welcome. 