### PR TITLE
Default to using 80% of cores available (instead of 100%) for indexing

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -3,6 +3,9 @@
 
 #include "config.hh"
 
+#include <algorithm>
+#include <thread>
+
 namespace ccls {
 Config *g_config;
 
@@ -15,5 +18,11 @@ void doPathMapping(std::string &arg) {
         arg.replace(p, sep, mapping.substr(sep + 1));
     }
   }
+}
+
+int defaultIndexThreadCount() {
+  constexpr float kIndexThreadUtilization = 0.8;
+  return std::max(1, static_cast<int>(std::thread::hardware_concurrency() *
+                                      kIndexThreadUtilization));
 }
 } // namespace ccls

--- a/src/config.hh
+++ b/src/config.hh
@@ -8,6 +8,10 @@
 #include <string>
 
 namespace ccls {
+
+// Select a reasonable default number of threads to use for indexing.
+int defaultIndexThreadCount();
+
 /*
 The language client plugin needs to send initialization options in the
 `initialize` request to the ccls language server.
@@ -286,7 +290,7 @@ struct Config {
     bool parametersInDeclarations = true;
 
     // Number of indexer threads. If 0, 80% of cores are used.
-    int threads = 0;
+    int threads = defaultIndexThreadCount();
 
     // Whether to reparse a file if write times of its dependencies have
     // changed. The file will always be reparsed if its own write time changes.

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -374,6 +374,10 @@ void do_initialize(MessageHandler *m, InitializeParam &param,
   // Start indexer threads. Start this after loading the project, as that
   // may take a long time. Indexer threads will emit status/progress
   // reports.
+  //
+  // By default config.hh will select 80% of the available cores to use as
+  // index threads, but explicitly specifying threads=0 will instead use all
+  // available cores.
   if (g_config->index.threads == 0)
     g_config->index.threads = (int)std::thread::hardware_concurrency();
 


### PR DESCRIPTION
This makes the behavior of ccls match the existing comment in `config.hh` saying that 80% of cores will be used for indexing by default. You can still use 100% of threads by specifying `index.threads=0`.