### PR TITLE
use SCHED_BATCH scheduling priority for indexing threads

### DIFF
--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -255,6 +255,7 @@ void *indexer(void *arg_) {
   delete arg;
   std::string name = "indexer" + std::to_string(idx);
   set_thread_name(name.c_str());
+  setBatchPriority();
   pipeline::indexer_Main(h->manager, h->vfs, h->project, h->wfiles);
   pipeline::threadLeave();
   return nullptr;

--- a/src/platform.hh
+++ b/src/platform.hh
@@ -17,4 +17,6 @@ void freeUnusedMemory();
 void traceMe();
 
 void spawnThread(void *(*fn)(void *), void *arg);
+
+void setBatchPriority();
 } // namespace ccls

--- a/src/platform_win.cc
+++ b/src/platform_win.cc
@@ -48,6 +48,8 @@ void traceMe() {}
 void spawnThread(void *(*fn)(void *), void *arg) {
   std::thread(fn, arg).detach();
 }
+
+void setBatchPriority() {}
 } // namespace ccls
 
 #endif


### PR DESCRIPTION
This uses `sched_setscheduler(2)` to set the Linux `SCHED_BATCH` policy for indexing threads. This will only work on Linux, on other Posix platforms the implementation of `setBatchPriority()` will be guarded out by an ifdef (arguably on other Posix systems you could set a nice value as an alternative to using `SCHED_BATCH`).

There's a good overview of this feature in [sched(7)](http://man7.org/linux/man-pages/man7/sched.7.html) and some benchmarks comparing it to nice values [here](https://barro.github.io/2016/02/being-a-good-cpu-neighbor/). Note that the scheduling policy is a separate concept than nice values, so users can still renice ccls processes.

The motivation for this change is to make ccls work a bit better on my workstation when I'm using other interactive programs (emacs itself, firefox, etc.) but also indexing a large amount of code.