### PR TITLE
set background thread priority on index threads

### DIFF
--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -12,6 +12,7 @@
 #include "working_files.hh"
 
 #include <llvm/ADT/Twine.h>
+#include <llvm/Config/llvm-config.h>
 #include <llvm/Support/Threading.h>
 
 #include <rapidjson/document.h>
@@ -255,6 +256,9 @@ void *indexer(void *arg_) {
   delete arg;
   std::string name = "indexer" + std::to_string(idx);
   set_thread_name(name.c_str());
+#if LLVM_ENABLE_THREADS && LLVM_VERSION_MAJOR >= 9
+  set_thread_priority(ThreadPriority::Background);
+#endif
   pipeline::indexer_Main(h->manager, h->vfs, h->project, h->wfiles);
   pipeline::threadLeave();
   return nullptr;


### PR DESCRIPTION
Previously I created #537 which uses the Linux-specific `SCHED_BATCH`, but then I noticed that LLVM has a platform-agnostic way of doing this that works on Windows, macOS, etc. Note that the LLVM implementation uses `SCHED_IDLE` on Linux which is much more extreme than `SCHED_BATCH`, but probably still OK for the indexer 🤷