### PR TITLE
textDocument/documentSymbol should work for non-opened files as well.

### DIFF
--- a/src/message_handler.cc
+++ b/src/message_handler.cc
@@ -252,9 +252,9 @@ QueryFile *MessageHandler::findFile(const std::string &path, int *out_file_id) {
 
 std::pair<QueryFile *, WorkingFile *>
 MessageHandler::findOrFail(const std::string &path, ReplyOnce &reply,
-                           int *out_file_id) {
+                           int *out_file_id, bool allow_unopened) {
   WorkingFile *wf = wfiles->getFile(path);
-  if (!wf) {
+  if (!wf && !allow_unopened) {
     reply.notOpened(path);
     return {nullptr, nullptr};
   }

--- a/src/message_handler.hh
+++ b/src/message_handler.hh
@@ -236,7 +236,8 @@ struct MessageHandler {
   QueryFile *findFile(const std::string &path, int *out_file_id = nullptr);
   std::pair<QueryFile *, WorkingFile *> findOrFail(const std::string &path,
                                                    ReplyOnce &reply,
-                                                   int *out_file_id = nullptr);
+                                                   int *out_file_id = nullptr,
+                                                   bool allow_unopened = false);
 
 private:
   void bind(const char *method, void (MessageHandler::*handler)(JsonReader &));

--- a/src/messages/textDocument_document.cc
+++ b/src/messages/textDocument_document.cc
@@ -147,8 +147,8 @@ void MessageHandler::textDocument_documentSymbol(JsonReader &reader,
 
   int file_id;
   auto [file, wf] =
-      findOrFail(param.textDocument.uri.getPath(), reply, &file_id);
-  if (!wf)
+      findOrFail(param.textDocument.uri.getPath(), reply, &file_id, true);
+  if (!file)
     return;
   auto allows = [&](SymbolRef sym) { return !(sym.role & param.excludeRole); };
 


### PR DESCRIPTION
I was trying to use ccls as a C/C++ server for the Apache NetBeans IDE, and it turned out the textDocument/documentSymbol only works for opened files. That is unfortunate, as NetBeans is using this request to fill the "Navigator", which generally works for any selected file, even those that are just selected in one of the files view. Moreover, the LSP specification says that: "Note that a server’s ability to fulfill requests is independent of whether a text document is open or closed.", so it would seem reasonable to me if the server would answer the query even for non-opened files. In the case of textDocument/documentSymbol, it seems this may be reasonably doable, see this patch.

What do you think?
