### PR TITLE
Convert llvm::StringRef -> std::string from implicit to explicit

### DIFF
--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -21,7 +21,7 @@ std::string pathFromFileEntry(const FileEntry &file) {
   StringRef name = file.tryGetRealPathName();
   if (name.empty())
     name = file.getName();
-  std::string ret = normalizePath(name);
+  std::string ret = normalizePath(name.str());
   // Resolve symlinks outside of workspace folders, e.g. /usr/include/c++/7.3.0
   return normalizeFolder(ret) ? ret : realPath(ret);
 }

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -31,7 +31,8 @@ void getFilesInFolder(std::string folder, bool recursive, bool dir_prefix,
       curr.pop_back();
       for (sys::fs::directory_iterator i(folder1, ec, false), e; i != e && !ec;
            i.increment(ec)) {
-        std::string path = i->path(), filename = sys::path::filename(path);
+        std::string path = i->path(),
+                    filename = sys::path::filename(path).str();
         if ((filename[0] == '.' && filename != ".ccls") ||
             sys::fs::status(path, status, false))
           continue;

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -508,7 +508,7 @@ public:
     llvm::raw_svector_ostream os(str);
     d->print(os, getDefaultPolicy());
 
-    std::string name = os.str();
+    std::string name = os.str().str();
     simplifyAnonymous(name);
     // Remove \n in DeclPrinter.cpp "{\n" + if(!TerseOutput)something + "}"
     for (std::string::size_type i = 0;;) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
     if (opt_index.size()) {
       SmallString<256> root(opt_index);
       sys::fs::make_absolute(root);
-      pipeline::standalone(root.str());
+      pipeline::standalone(root.str().str());
     } else {
       // The thread that reads from stdin and dispatchs commands to the main
       // thread.

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -297,7 +297,7 @@ void do_initialize(MessageHandler *m, InitializeParam &param,
       SmallString<256> path(g_config->cache.directory);
       sys::fs::make_absolute(project_path, path);
       // Use upper case for the Driver letter on Windows.
-      g_config->cache.directory = normalizePath(path.str());
+      g_config->cache.directory = normalizePath(path.str().str());
       ensureEndsInSlash(g_config->cache.directory);
     }
   }

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -113,7 +113,7 @@ bool cacheInvalid(VFS *vfs, IndexFile *prev, const std::string &path,
   }
 
   // For inferred files, allow -o a a.cc -> -o b b.cc
-  std::string stem = sys::path::stem(path);
+  std::string stem = sys::path::stem(path).str();
   int changed = -1, size = std::min(prev->args.size(), args.size());
   for (int i = 0; i < size; i++)
     if (strcmp(prev->args[i], args[i]) && sys::path::stem(args[i]) != stem) {

--- a/src/project.cc
+++ b/src/project.cc
@@ -226,7 +226,7 @@ readCompilerArgumentsFromFile(const std::string &path) {
     return {};
   std::vector<const char *> args;
   for (line_iterator i(*mbOrErr.get(), true, '#'), e; i != e; ++i) {
-    std::string line = *i;
+    std::string line = i->str();
     doPathMapping(line);
     args.push_back(intern(line));
   }
@@ -641,7 +641,7 @@ void Project::index(WorkingFiles *wfiles, const RequestId &id) {
 void Project::indexRelated(const std::string &path) {
   auto &gi = g_config->index;
   GroupMatch match(gi.whitelist, gi.blacklist);
-  std::string stem = sys::path::stem(path);
+  std::string stem = sys::path::stem(path).str();
   std::vector<const char *> args, extra_args;
   for (const std::string &arg : g_config->clang.extraArgs)
     extra_args.push_back(intern(arg));

--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -622,7 +622,7 @@ void *diagnosticMain(void *manager_) {
         for (const Note &n : d.notes) {
           SmallString<256> str(n.file);
           llvm::sys::path::remove_dots(str, true);
-          Location loc{DocumentUri::fromPath(str.str()),
+          Location loc{DocumentUri::fromPath(str.str().str()),
                        lsRange{{n.range.start.line, n.range.start.column},
                                {n.range.end.line, n.range.end.column}}};
           ls_diag.relatedInformation.push_back({loc, n.message});

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -218,7 +218,7 @@ void reflect(JsonWriter &vis, IndexInclude &v) {
   reflectMemberStart(vis);
   REFLECT_MEMBER(line);
   if (gTestOutputMode) {
-    std::string basename = llvm::sys::path::filename(v.resolved_path);
+    std::string basename = llvm::sys::path::filename(v.resolved_path).str();
     if (v.resolved_path[0] != '&')
       basename = "&" + basename;
     REFLECT_MEMBER2("resolved_path", basename);

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -128,7 +128,7 @@ std::string resolveIfRelative(const std::string &directory,
     return path;
   SmallString<256> ret;
   sys::path::append(ret, directory, path);
-  return normalizePath(ret.str());
+  return normalizePath(ret.str().str());
 }
 
 std::string realPath(const std::string &path) {


### PR DESCRIPTION
A change in llvm 11 changed the llvm::StringRef API to disable implicit
casts from llvm::StringRef to std::string. Convert all calls here to
the explicit API.