### PR TITLE
Treat function-scope static variables as locals

### DIFF
--- a/src/indexer.hh
+++ b/src/indexer.hh
@@ -247,7 +247,7 @@ struct VarDef : NameMixin<VarDef> {
             parent_kind == SymbolKind::StaticMethod ||
             parent_kind == SymbolKind::Constructor) &&
            (storage == clang::SC_None || storage == clang::SC_Auto ||
-            storage == clang::SC_Register);
+            storage == clang::SC_Register || storage == clang::SC_Static);
   }
 
   const Usr *bases_begin() const { return nullptr; }


### PR DESCRIPTION
If we report such variables as symbols in response to a
`textDocument/documentSymbol`, then we can no longer navigate to the
containing function using imenu in emacs.

Fixes [#77](https://github.com/MaskRay/emacs-ccls/issues/77)