### PR TITLE
fix: compile error

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -685,7 +685,7 @@ public:
   bool handleDeclOccurrence(const Decl *d, index::SymbolRoleSet roles,
                             ArrayRef<index::SymbolRelation> relations,
                             SourceLocation src_loc,
-                            ASTNodeInfo ast_node) override {
+                            ASTNodeInfo ast_node) {
     if (!param.no_linkage) {
       if (auto *nd = dyn_cast<NamedDecl>(d); nd && nd->hasLinkage())
         ;


### PR DESCRIPTION
handleDeclOccurrence(const clang::Decl*, clang::index::SymbolRoleSet, llvm::ArrayRef<clang::index::SymbolRelation>, clang::SourceLocation, clang::index::IndexDataConsumer::ASTNodeInfo)’ marked ‘override’, but does not override
   bool handleDeclOccurrence(const Decl *d, index::SymbolRoleSet roles,
        ^~~~~~~~~~~~~~~~~~~~