### PR TITLE
Minor modernization

### DIFF
--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "clang_tu.hh"
@@ -124,7 +124,7 @@ buildCompilerInvocation(const std::string &main, std::vector<const char *> args,
     if (!offload_compilation)
       return nullptr;
   }
-  if (jobs.size() == 0 || !isa<driver::Command>(*jobs.begin()))
+  if (jobs.empty() || !isa<driver::Command>(*jobs.begin()))
     return nullptr;
 
   const driver::Command &cmd = cast<driver::Command>(*jobs.begin());

--- a/src/indexer.hh
+++ b/src/indexer.hh
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -72,16 +72,16 @@ struct SymbolRef {
   Kind kind;
   Role role;
   operator SymbolIdx() const { return {usr, kind}; }
-  std::tuple<Range, Usr, Kind, Role> toTuple() const {
+  [[nodiscard]] std::tuple<Range, Usr, Kind, Role> toTuple() const {
     return std::make_tuple(range, usr, kind, role);
   }
   bool operator==(const SymbolRef &o) const { return toTuple() == o.toTuple(); }
-  bool valid() const { return range.valid(); }
+  [[nodiscard]] bool valid() const { return range.valid(); }
 };
 
 struct ExtentRef : SymbolRef {
   Range extent;
-  std::tuple<Range, Usr, Kind, Role, Range> toTuple() const {
+  [[nodiscard]] std::tuple<Range, Usr, Kind, Role, Range> toTuple() const {
     return std::make_tuple(range, usr, kind, role, extent);
   }
   bool operator==(const ExtentRef &o) const { return toTuple() == o.toTuple(); }
@@ -92,7 +92,7 @@ struct Ref {
   Role role;
 
   bool valid() const { return range.valid(); }
-  std::tuple<Range, Role> toTuple() const {
+  [[nodiscard]] std::tuple<Range, Role> toTuple() const {
     return std::make_tuple(range, role);
   }
   bool operator==(const Ref &o) const { return toTuple() == o.toTuple(); }
@@ -130,7 +130,7 @@ void reflect(BinaryWriter &visitor, DeclRef &value);
 template <typename T> using VectorAdapter = std::vector<T, std::allocator<T>>;
 
 template <typename D> struct NameMixin {
-  std::string_view name(bool qualified) const {
+  [[nodiscard]] std::string_view name(bool qualified) const {
     auto self = static_cast<const D *>(this);
     return qualified
                ? std::string_view(self->detailed_name + self->qual_name_offset,
@@ -165,8 +165,8 @@ struct FuncDef : NameMixin<FuncDef<V>> {
   SymbolKind parent_kind = SymbolKind::Unknown;
   uint8_t storage = clang::SC_None;
 
-  const Usr *bases_begin() const { return bases.begin(); }
-  const Usr *bases_end() const { return bases.end(); }
+  [[nodiscard]] const Usr *bases_begin() const { return bases.begin(); }
+  [[nodiscard]] const Usr *bases_end() const { return bases.end(); }
 };
 REFLECT_STRUCT(FuncDef<VectorAdapter>, detailed_name, hover, comments, spell,
                bases, vars, callees, qual_name_offset, short_name_offset,
@@ -204,8 +204,8 @@ struct TypeDef : NameMixin<TypeDef<V>> {
   SymbolKind kind = SymbolKind::Unknown;
   SymbolKind parent_kind = SymbolKind::Unknown;
 
-  const Usr *bases_begin() const { return bases.begin(); }
-  const Usr *bases_end() const { return bases.end(); }
+  [[nodiscard]] const Usr *bases_begin() const { return bases.begin(); }
+  [[nodiscard]] const Usr *bases_end() const { return bases.end(); }
 };
 REFLECT_STRUCT(TypeDef<VectorAdapter>, detailed_name, hover, comments, spell,
                bases, funcs, types, vars, alias_of, qual_name_offset,
@@ -240,7 +240,7 @@ struct VarDef : NameMixin<VarDef> {
   // (declaration).
   uint8_t storage = clang::SC_None;
 
-  bool is_local() const {
+  [[nodiscard]] bool is_local() const {
     return spell &&
            (parent_kind == SymbolKind::Function ||
             parent_kind == SymbolKind::Method ||
@@ -250,8 +250,8 @@ struct VarDef : NameMixin<VarDef> {
             storage == clang::SC_Register);
   }
 
-  const Usr *bases_begin() const { return nullptr; }
-  const Usr *bases_end() const { return nullptr; }
+  [[nodiscard]] const Usr *bases_begin() const { return nullptr; }
+  [[nodiscard]] const Usr *bases_end() const { return nullptr; }
 };
 REFLECT_STRUCT(VarDef, detailed_name, hover, comments, spell, type,
                qual_name_offset, short_name_offset, short_name_size, kind,

--- a/src/lsp.hh
+++ b/src/lsp.hh
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -22,7 +22,7 @@ struct RequestId {
 
   std::string value;
 
-  bool valid() const { return type != kNone; }
+  [[nodiscard]] bool valid() const { return type != kNone; }
 };
 void reflect(JsonReader &visitor, RequestId &value);
 void reflect(JsonWriter &visitor, RequestId &value);
@@ -67,7 +67,7 @@ struct DocumentUri {
   bool operator<(const DocumentUri &o) const { return raw_uri < o.raw_uri; }
 
   void setPath(const std::string &path);
-  std::string getPath() const;
+  [[nodiscard]] std::string getPath() const;
 
   std::string raw_uri;
 };
@@ -84,7 +84,7 @@ struct Position {
   bool operator<=(const Position &o) const {
     return line != o.line ? line < o.line : character <= o.character;
   }
-  std::string toString() const;
+  [[nodiscard]] std::string toString() const;
 };
 
 struct lsRange {
@@ -96,10 +96,10 @@ struct lsRange {
   bool operator<(const lsRange &o) const {
     return !(start == o.start) ? start < o.start : end < o.end;
   }
-  bool includes(const lsRange &o) const {
+  [[nodiscard]] bool includes(const lsRange &o) const {
     return start <= o.start && o.end <= end;
   }
-  bool intersects(const lsRange &o) const {
+  [[nodiscard]] bool intersects(const lsRange &o) const {
     return start < o.end && o.start < end;
   }
 };

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "filesystem.hh"
@@ -255,7 +255,7 @@ void *indexer(void *arg_) {
   std::tie(h, idx) = *arg;
   delete arg;
   std::string name = "indexer" + std::to_string(idx);
-  set_thread_name(name.c_str());
+  set_thread_name(name);
   // Don't lower priority on __APPLE__. getpriority(2) says "When setting a
   // thread into background state the scheduling priority is set to lowest
   // value, disk and network IO are throttled."

--- a/src/messages/textDocument_hover.cc
+++ b/src/messages/textDocument_hover.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "message_handler.hh"
@@ -37,7 +37,7 @@ const char *languageIdentifier(LanguageId lang) {
   case LanguageId::ObjC: return "objective-c";
   case LanguageId::ObjCpp: return "objective-cpp";
   default: return "";
-    // clang-format on
+  // clang-format on
   }
 }
 

--- a/src/query.cc
+++ b/src/query.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "query.hh"
@@ -61,7 +61,7 @@ template <typename Q>
 bool tryReplaceDef(llvm::SmallVectorImpl<Q> &def_list, Q &&def) {
   for (auto &def1 : def_list)
     if (def1.file_id == def.file_id) {
-      def1 = std::move(def);
+      def1 = std::forward<Q>(def);
       return true;
     }
   return false;

--- a/src/query.hh
+++ b/src/query.hh
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -57,7 +57,7 @@ template <typename Q, typename QDef> struct QueryEntity {
     }
     return ret;
   }
-  const Def *anyDef() const {
+  [[nodiscard]] const Def *anyDef() const {
     return const_cast<QueryEntity *>(this)->anyDef();
   }
 };

--- a/src/serializer.hh
+++ b/src/serializer.hh
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -41,7 +41,7 @@ struct JsonReader {
   void member(const char *name, llvm::function_ref<void()> fn);
   bool isNull();
   std::string getString();
-  std::string getPath() const;
+  [[nodiscard]] std::string getPath() const;
 };
 
 struct JsonWriter {

--- a/src/threaded_queue.hh
+++ b/src/threaded_queue.hh
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -29,8 +29,8 @@ struct BaseThreadQueue {
 template <typename... Queue> struct MultiQueueLock {
   MultiQueueLock(Queue... lockable) : tuple_{lockable...} { lock(); }
   ~MultiQueueLock() { unlock(); }
-  void lock() { lock_impl(typename std::index_sequence_for<Queue...>{}); }
-  void unlock() { unlock_impl(typename std::index_sequence_for<Queue...>{}); }
+  void lock() { lock_impl(std::index_sequence_for<Queue...>{}); }
+  void unlock() { unlock_impl(std::index_sequence_for<Queue...>{}); }
 
 private:
   template <size_t... Is> void lock_impl(std::index_sequence<Is...>) {
@@ -123,7 +123,7 @@ public:
   }
 
   // Returns true if the queue is empty. This is lock-free.
-  bool isEmpty() { return total_count_ == 0; }
+  [[nodiscard]] bool isEmpty() override { return total_count_ == 0; }
 
   // Get the first element from the queue. Blocks until one is available.
   T dequeue() {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #include "utils.hh"
@@ -37,7 +37,7 @@ Matcher::Matcher(const std::string &pattern)
                                         std::regex_constants::optimize);
 }
 
-Matcher::~Matcher() {}
+Matcher::~Matcher() = default;
 
 bool Matcher::matches(const std::string &text) const {
   return std::regex_search(text, impl->regex, std::regex_constants::match_any);

--- a/src/utils.hh
+++ b/src/utils.hh
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 ccls Authors
+// Copyright 2017-2020 ccls Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -25,7 +25,7 @@ struct Matcher {
   Matcher(const std::string &pattern); // throw
   Matcher(Matcher &&) = default;
   ~Matcher();
-  bool matches(const std::string &text) const;
+  [[nodiscard]] bool matches(const std::string &text) const;
 };
 
 struct GroupMatch {
@@ -114,7 +114,7 @@ public:
   const T &operator*() const { return storage; }
   T &operator*() { return storage; }
 
-  bool valid() const { return storage.valid(); }
+  [[nodiscard]] bool valid() const { return storage.valid(); }
   explicit operator bool() const { return valid(); }
   operator std::optional<T>() const {
     if (valid())
@@ -148,7 +148,7 @@ template <typename T> struct Vec {
   T *begin() { return a.get(); }
   const T *end() const { return a.get() + s; }
   T *end() { return a.get() + s; }
-  int size() const { return s; }
+  [[nodiscard]] int size() const { return s; }
   const T &operator[](size_t i) const { return a.get()[i]; }
   T &operator[](size_t i) { return a.get()[i]; }
 };


### PR DESCRIPTION
Includes

- add `[[nodiscard]]` attribute for some functions
- change `jobs.size() == 0` to `jobs.empty()`
- remove `typename` in `void lock() { lock_impl(typename std::index_sequence_for<Queue...>{}); }`. There is no dependent type contextually.
- In `path = root + path.substr(real.size())` statement, `.substr()` returns a temporary `std::string`, and the `operator+` returns another one.  Let's optimize the second out.