### PR TITLE
Fail loudly when found rapidjson is too old

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ set_property(SOURCE src/utils.cc APPEND PROPERTY COMPILE_DEFINITIONS
 if(USE_SYSTEM_RAPIDJSON)
   find_package(RapidJSON QUIET)
   if(NOT DEFINED RapidJSON_INCLUDE_DIRS AND DEFINED RAPIDJSON_INCLUDE_DIRS)
-    message(FATAL_ERROR "RapidJSON version is likely too old. See https://github.com/MaskRay/ccls/issues/455.")
+    message(FATAL_ERROR "RapidJSON version is likely too old. See https://github.com/MaskRay/ccls/issues/455")
   endif()
 endif()
 if(NOT RapidJSON_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,9 @@ set_property(SOURCE src/utils.cc APPEND PROPERTY COMPILE_DEFINITIONS
 
 if(USE_SYSTEM_RAPIDJSON)
   find_package(RapidJSON QUIET)
+  if(NOT DEFINED RapidJSON_INCLUDE_DIRS AND DEFINED RAPIDJSON_INCLUDE_DIRS)
+    message(FATAL_ERROR "RapidJSON version is likely too old. See https://github.com/MaskRay/ccls/issues/455.")
+  endif()
 endif()
 if(NOT RapidJSON_FOUND)
   set(RapidJSON_INCLUDE_DIRS third_party/rapidjson/include)


### PR DESCRIPTION
When the rapidjson found by cmake is an older version it defines a
variable `RAPIDJSON_INCLUDE_DIRS` instead of `RapidJSON_INCLUDE_DIRS` (#455).
According to #383 we do not want to make these older versions work with
ccls. However currently if the rapidjson found by cmake is an older
version that defined `RAPIDJSON_INCLUDE_DIRS` then the cmake invocation
still succeeds but the build command will fail because
`RapidJSON_INCLUDE_DIRS` was never set properly.

This PR makes the cmake invocation fail with a relevant error message in this event.

I think this would be useful because the homebrew version of rapidjson still defines RAPIDJSON_INCLUDE_DIRS so this issue is likely to come up for people on macOS. Especially since `-DUSE_SYSTEM_RAPIDJSON=on` is default now.