### PR TITLE
Do not use system RapidJSON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(ccls LANGUAGES CXX)
 
-option(USE_SYSTEM_RAPIDJSON "Use system RapidJSON instead of the git submodule if exists" ON)
+option(USE_SYSTEM_RAPIDJSON "Use system RapidJSON instead of the git submodule if exists" OFF)
 
 # Sources for the executable are specified at end of CMakeLists.txt
 add_executable(ccls "")


### PR DESCRIPTION
Now that we check some variables to see if rapidjson isn't too old and errors if this is the case #646, shouldn't we use the provided rapidjson by default? or at least not `message(FATAL_ERROR`?