### PR TITLE
indexer: log the number of errors and the first diagnostic

### DIFF
--- a/src/indexer.hh
+++ b/src/indexer.hh
@@ -322,13 +322,19 @@ struct IndexFile {
   std::string toString();
 };
 
+struct IndexResult {
+  std::vector<std::unique_ptr<IndexFile>> indexes;
+  int n_errs = 0;
+  std::string first_error;
+};
+
 struct SemaManager;
 struct WorkingFiles;
 struct VFS;
 
 namespace idx {
 void init();
-std::vector<std::unique_ptr<IndexFile>>
+IndexResult
 index(SemaManager *complete, WorkingFiles *wfiles, VFS *vfs,
       const std::string &opt_wdir, const std::string &file,
       const std::vector<const char *> &args,

--- a/src/test.cc
+++ b/src/test.cc
@@ -315,15 +315,15 @@ bool runIndexTests(const std::string &filter_path, bool enable_update) {
         for (auto &arg : flags)
           cargs.push_back(arg.c_str());
         bool ok;
-        auto dbs = ccls::idx::index(&completion, &wfiles, &vfs, "", path, cargs,
-                                    {}, true, ok);
+        auto result = ccls::idx::index(&completion, &wfiles, &vfs, "", path,
+                                       cargs, {}, true, ok);
 
         for (const auto &entry : all_expected_output) {
           const std::string &expected_path = entry.first;
           std::string expected_output = text_replacer.apply(entry.second);
 
           // Get output from index operation.
-          IndexFile *db = findDbForPathEnding(expected_path, dbs);
+          IndexFile *db = findDbForPathEnding(expected_path, result.indexes);
           std::string actual_output = "{}";
           if (db) {
             verifySerializeToFrom(db);


### PR DESCRIPTION
Example log:

```
15:47:45 indexer1         pipeline.cc:379 I parse /tmp/d/a.c error:1 use of undeclared identifier 'arg'
 clang /tmp/d/a.c --gcc-toolchain=/usr -working-directory=/tmp/d/
```