### PR TITLE
fix outline and breadcumbs for members definition in namespace

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: LLVM
+IndentPPDirectives: AfterHash

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -785,7 +785,10 @@ public:
         entity->def.spell = {use,
                              fromTokenRangeDefaulted(sm, lang, sr, fid, loc)};
         entity->def.parent_kind = SymbolKind::File;
-        getKind(cast<Decl>(sem_dc), entity->def.parent_kind);
+        const Decl *dc = cast<Decl>(sem_dc);
+        if (Kind parent_kind = getKind(dc, entity->def.parent_kind);
+            parent_kind != Kind::Invalid)
+          entity->def.parent = {getUsr(dc), parent_kind};
       } else if (is_decl) {
         SourceRange sr = origD->getSourceRange();
         entity->declarations.push_back(
@@ -1205,7 +1208,7 @@ public:
 };
 } // namespace
 
-const int IndexFile::kMajorVersion = 21;
+const int IndexFile::kMajorVersion = 22;
 const int IndexFile::kMinorVersion = 0;
 
 IndexFile::IndexFile(const std::string &path, const std::string &contents,

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -687,7 +687,7 @@ public:
   IndexDataConsumer(IndexParam &param) : param(param) {}
   void initialize(ASTContext &ctx) override { this->ctx = param.ctx = &ctx; }
 #if LLVM_VERSION_MAJOR < 10 // llvmorg-10-init-12036-g3b9715cb219
-# define handleDeclOccurrence handleDeclOccurence
+#  define handleDeclOccurrence handleDeclOccurence
 #endif
   bool handleDeclOccurrence(const Decl *d, index::SymbolRoleSet roles,
                             ArrayRef<index::SymbolRelation> relations,
@@ -888,10 +888,10 @@ public:
                 Usr usr1 = getUsr(d1, &info1);
                 IndexType &type1 = db->toType(usr1);
                 SourceLocation sl1 = d1->getLocation();
-                type1.def.spell = {
-                    Use{{fromTokenRange(sm, lang, {sl1, sl1}), Role::Definition},
-                        lid},
-                    fromTokenRange(sm, lang, sr1)};
+                type1.def.spell = {Use{{fromTokenRange(sm, lang, {sl1, sl1}),
+                                        Role::Definition},
+                                       lid},
+                                   fromTokenRange(sm, lang, sr1)};
                 type1.def.detailed_name = intern(info1->short_name);
                 type1.def.short_name_size = int16_t(info1->short_name.size());
                 type1.def.kind = SymbolKind::TypeParameter;

--- a/src/indexer.hh
+++ b/src/indexer.hh
@@ -65,6 +65,8 @@ struct SymbolIdx {
   }
 };
 
+REFLECT_STRUCT(SymbolIdx, usr, kind);
+
 // |id,kind| refer to the referenced entity.
 struct SymbolRef {
   Range range;
@@ -163,6 +165,7 @@ struct FuncDef : NameMixin<FuncDef<V>> {
   int16_t short_name_size = 0;
   SymbolKind kind = SymbolKind::Unknown;
   SymbolKind parent_kind = SymbolKind::Unknown;
+  SymbolIdx parent = {0, Kind::Invalid};
   uint8_t storage = clang::SC_None;
 
   const Usr *bases_begin() const { return bases.begin(); }
@@ -170,7 +173,7 @@ struct FuncDef : NameMixin<FuncDef<V>> {
 };
 REFLECT_STRUCT(FuncDef<VectorAdapter>, detailed_name, hover, comments, spell,
                bases, vars, callees, qual_name_offset, short_name_offset,
-               short_name_size, kind, parent_kind, storage);
+               short_name_size, kind, parent_kind, parent, storage);
 
 struct IndexFunc : NameMixin<IndexFunc> {
   using Def = FuncDef<VectorAdapter>;
@@ -203,13 +206,14 @@ struct TypeDef : NameMixin<TypeDef<V>> {
   int16_t short_name_size = 0;
   SymbolKind kind = SymbolKind::Unknown;
   SymbolKind parent_kind = SymbolKind::Unknown;
+  SymbolIdx parent = {0, Kind::Invalid};
 
   const Usr *bases_begin() const { return bases.begin(); }
   const Usr *bases_end() const { return bases.end(); }
 };
 REFLECT_STRUCT(TypeDef<VectorAdapter>, detailed_name, hover, comments, spell,
                bases, funcs, types, vars, alias_of, qual_name_offset,
-               short_name_offset, short_name_size, kind, parent_kind);
+               short_name_offset, short_name_size, kind, parent_kind, parent);
 
 struct IndexType {
   using Def = TypeDef<VectorAdapter>;
@@ -236,6 +240,7 @@ struct VarDef : NameMixin<VarDef> {
   int16_t short_name_size = 0;
   SymbolKind kind = SymbolKind::Unknown;
   SymbolKind parent_kind = SymbolKind::Unknown;
+  SymbolIdx parent = {0, Kind::Invalid};
   // Note a variable may have instances of both |None| and |Extern|
   // (declaration).
   uint8_t storage = clang::SC_None;
@@ -255,7 +260,7 @@ struct VarDef : NameMixin<VarDef> {
 };
 REFLECT_STRUCT(VarDef, detailed_name, hover, comments, spell, type,
                qual_name_offset, short_name_offset, short_name_size, kind,
-               parent_kind, storage);
+               parent_kind, parent, storage);
 
 struct IndexVar {
   using Def = VarDef;

--- a/src/query.cc
+++ b/src/query.cc
@@ -90,6 +90,7 @@ QueryFunc::Def convert(const IndexFunc::Def &o) {
   r.short_name_size = o.short_name_size;
   r.kind = o.kind;
   r.parent_kind = o.parent_kind;
+  r.parent = o.parent;
   r.storage = o.storage;
   return r;
 }
@@ -111,6 +112,7 @@ QueryType::Def convert(const IndexType::Def &o) {
   r.short_name_size = o.short_name_size;
   r.kind = o.kind;
   r.parent_kind = o.parent_kind;
+  r.parent = o.parent;
   return r;
 }
 
@@ -839,4 +841,20 @@ std::vector<SymbolRef> findSymbolsAtLocation(WorkingFile *wfile,
 
   return symbols;
 }
+
+std::optional<SymbolIdx> getNamespace(DB *db, SymbolIdx sym) {
+  SymbolKind kind;
+  do {
+    withEntity(db, sym,
+               [&sym](auto const &entity) { sym = entity.anyDef()->parent; });
+    kind = getSymbolKind(db, sym);
+  } while (kind != SymbolKind::Namespace && kind != SymbolKind::File &&
+           kind != SymbolKind::Unknown);
+
+  if (kind == SymbolKind::Namespace)
+    return sym;
+  else
+    return std::nullopt;
+}
+
 } // namespace ccls

--- a/src/query.hh
+++ b/src/query.hh
@@ -258,6 +258,8 @@ void eachOccurrence(DB *db, SymbolIdx sym, bool include_decl, Fn &&fn) {
 
 SymbolKind getSymbolKind(DB *db, SymbolIdx sym);
 
+std::optional<SymbolIdx> getNamespace(DB *db, SymbolIdx sym);
+
 template <typename C, typename Fn>
 void eachDefinedFunc(DB *db, const C &usrs, Fn &&fn) {
   for (Usr usr : usrs) {

--- a/src/serializer.cc
+++ b/src/serializer.cc
@@ -297,6 +297,7 @@ template <typename TVisitor> void reflect1(TVisitor &vis, IndexFunc &v) {
   REFLECT_MEMBER2("callees", v.def.callees);
   REFLECT_MEMBER2("kind", v.def.kind);
   REFLECT_MEMBER2("parent_kind", v.def.parent_kind);
+  REFLECT_MEMBER2("parent", v.def.parent);
   REFLECT_MEMBER2("storage", v.def.storage);
 
   REFLECT_MEMBER2("declarations", v.declarations);
@@ -324,6 +325,7 @@ template <typename Vis> void reflect1(Vis &vis, IndexType &v) {
   REFLECT_MEMBER2("alias_of", v.def.alias_of);
   REFLECT_MEMBER2("kind", v.def.kind);
   REFLECT_MEMBER2("parent_kind", v.def.parent_kind);
+  REFLECT_MEMBER2("parent", v.def.parent);
 
   REFLECT_MEMBER2("declarations", v.declarations);
   REFLECT_MEMBER2("derived", v.derived);
@@ -347,6 +349,7 @@ template <typename TVisitor> void reflect1(TVisitor &vis, IndexVar &v) {
   REFLECT_MEMBER2("type", v.def.type);
   REFLECT_MEMBER2("kind", v.def.kind);
   REFLECT_MEMBER2("parent_kind", v.def.parent_kind);
+  REFLECT_MEMBER2("parent", v.def.parent);
   REFLECT_MEMBER2("storage", v.def.storage);
 
   REFLECT_MEMBER2("declarations", v.declarations);


### PR DESCRIPTION
When we have members defined outside the class in a namespace in a separate file, the namespace doesn't have the members as children. The outline and breadcrumbs don't work correctly for them.
Before:
![Screenshot_20200702_214411](https://user-images.githubusercontent.com/24270152/86407323-1ffd0700-bcb5-11ea-8673-fa72fd87b9b8.png)
After:
![Screenshot_20200702_213950](https://user-images.githubusercontent.com/24270152/86407361-330fd700-bcb5-11ea-82b9-d96d9a463180.png)

I also refactored a little by removing `void*` and replacing it with `if constexpr` see the first commit if it suits your requirements.

There are other bugs with outline that I noticed which I am working on:
- [x] static member variable aren't in their class/struct
- [ ] defined member functions after the class definition in the same file override the member function declaration
- [ ] inline namespace