### PR TITLE
fix when workspace has soft link; eg: /home/Abbyyan->/data/home/Abbya…

### DIFF
--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -17,13 +17,13 @@
 #include <llvm/Support/Path.h>
 
 using namespace clang;
+using namespace llvm;
 
 namespace ccls {
 std::string pathFromFileEntry(const FileEntry &file) {
-  StringRef name = file.tryGetRealPathName();
-  if (name.empty())
-    name = file.getName();
-  std::string ret = normalizePath(name);
+  SmallString<128> path(file.getName());
+  sys::path::remove_dots(path, /*remove_dot_dot=*/true);
+  std::string ret(path.str());
   // Resolve symlinks outside of workspace folders, e.g. /usr/include/c++/7.3.0
   return normalizeFolder(ret) ? ret : realPath(ret);
 }

--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -6,6 +6,7 @@
 #include "config.hh"
 #include "platform.hh"
 
+#include <filesystem>
 #include <clang/AST/Type.h>
 #include <clang/Driver/Action.h>
 #include <clang/Driver/Compilation.h>
@@ -33,6 +34,7 @@ std::string pathFromFileEntry(const FileEntry &file) {
   std::string ret(path.str());
   if (checkFolder(ret))
     return ret;
+  ret = std::filesystem::exists(ret)? ret: file.tryGetRealPathName().str(); 
   // Resolve symlinks outside of workspace folders, e.g. /usr/include/c++/7.3.0
   return normalizeFolder(ret) ? ret : realPath(ret);
 }

--- a/src/clang_tu.hh
+++ b/src/clang_tu.hh
@@ -20,6 +20,8 @@ namespace vfs = clang::vfs;
 namespace ccls {
 std::string pathFromFileEntry(const clang::FileEntry &file);
 
+bool checkFolder(std::string &path);
+
 bool isInsideMainFile(const clang::SourceManager &sm, clang::SourceLocation sl);
 
 Range fromCharSourceRange(const clang::SourceManager &sm,

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -348,17 +348,16 @@ void do_initialize(MessageHandler *m, InitializeParam &param,
     std::string path = wf.uri.getPath();
     ensureEndsInSlash(path);
     std::string real = realPath(path) + '/';
-    workspaceFolders.emplace_back(path, path == real ? "" : real);
+    workspaceFolders.emplace_back(path, real);
   }
   if (workspaceFolders.empty()) {
     std::string real = realPath(project_path) + '/';
-    workspaceFolders.emplace_back(project_path,
-                                  project_path == real ? "" : real);
+    workspaceFolders.emplace_back(project_path, real);
   }
   std::sort(workspaceFolders.begin(), workspaceFolders.end(),
             [](auto &l, auto &r) { return l.first.size() > r.first.size(); });
   for (auto &[folder, real] : workspaceFolders)
-    if (real.empty())
+    if (real == folder)
       LOG_S(INFO) << "workspace folder: " << folder;
     else
       LOG_S(INFO) << "workspace folder: " << folder << " -> " << real;

--- a/src/project.cc
+++ b/src/project.cc
@@ -435,8 +435,9 @@ void Project::loadDirectory(const std::string &root, Project::Folder &folder) {
       entry.directory = realPath(cmd.Directory);
       normalizeFolder(entry.directory);
       doPathMapping(entry.directory);
-      entry.filename =
-          realPath(resolveIfRelative(entry.directory, cmd.Filename));
+      std::string resolvedPath =
+          resolveIfRelative(entry.directory, cmd.Filename);
+      entry.filename = realPath(resolvedPath);
       normalizeFolder(entry.filename);
       doPathMapping(entry.filename);
 
@@ -463,10 +464,17 @@ void Project::loadDirectory(const std::string &root, Project::Folder &folder) {
       if (seen.insert(entry.filename).second)
         folder.entries.push_back(entry);
 
-      if (cmd.Filename != entry.filename && seen.insert(cmd.Filename).second) {
-        Project::Entry entry_origin = entry;
-        entry_origin.filename = cmd.Filename;
-        folder.entries.push_back(entry_origin);
+      if (resolvedPath != entry.filename && seen.insert(resolvedPath).second) {
+        Project::Entry newEntry = entry;
+        newEntry.filename = resolvedPath;
+        folder.entries.push_back(newEntry);
+      }
+
+      normalizeFolder(resolvedPath);
+      if (resolvedPath != entry.filename && seen.insert(resolvedPath).second) {
+        Project::Entry newEntry = entry;
+        newEntry.filename = resolvedPath;
+        folder.entries.push_back(newEntry);
       }
     }
   }

--- a/src/project.cc
+++ b/src/project.cc
@@ -462,6 +462,12 @@ void Project::loadDirectory(const std::string &root, Project::Folder &folder) {
 
       if (seen.insert(entry.filename).second)
         folder.entries.push_back(entry);
+
+      if (cmd.Filename != entry.filename && seen.insert(cmd.Filename).second) {
+        Project::Entry entry_origin = entry;
+        entry_origin.filename = cmd.Filename;
+        folder.entries.push_back(entry_origin);
+      }
     }
   }
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -139,7 +139,7 @@ std::string realPath(const std::string &path) {
 
 bool normalizeFolder(std::string &path) {
   for (auto &[root, real] : g_config->workspaceFolders)
-    if (real.size() && llvm::StringRef(path).startswith(real)) {
+    if (StringRef(path).startswith(real)) {
       path = root + path.substr(real.size());
       return true;
     }


### PR DESCRIPTION
Fix with 99f0b402a7584f92de12f0af164ad7e0c772fcd2 。
I test on 99f0b402a7584f92de12f0af164ad7e0c772fcd2 and it may fail in such situation. 
Workspace `/home/Abbyyan/workspace` is a soft link and links to `/data/Abbyyan/workspace`， while the opened file `/home/Abbyyan/workspace/test1/main.cpp ` also  has soft link  whose dir `test1` links to `test2`. 
```shell
/home/Abbyyan/workspace -> /data/Abbyyan/workspace
/home/Abbyyan/workspace/test1/main.cpp -> /data/Abbyyan/workspace/test2/main.cpp
```
In this case, the function `normalizeFolder` in `src/utils.cc`  https://github.com/MaskRay/ccls/blob/99f0b402a7584f92de12f0af164ad7e0c772fcd2/src/utils.cc#L140 should return `True` to use the soft link path . While now it will return False and get the absolute path. So when i open with `/home/Abbyyan/workspace/test1/main.cpp ` , the index can't be find.  Maybe it should change as follows.
```c++
bool normalizeFolder(std::string &path) {
  for (auto &[root, real] : g_config->workspaceFolders) {
    if (StringRef(path).startswith(real)) {
      path = root + path.substr(real.size());
      return true;
    } else if (StringRef(path).startswith(root)) {
      return true;
    }
  }

  return false;
}
```
This function is also used in other places.  I am not sure if it will affect other places, so i add a new function in this pull request. 
