### PR TITLE
clang format, indent pp directives

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: LLVM
+IndentPPDirectives: AfterHash

--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -119,7 +119,7 @@ buildCompilerInvocation(const std::string &main, std::vector<const char *> args,
   const driver::JobList &jobs = comp->getJobs();
   bool offload_compilation = false;
   if (jobs.size() > 1) {
-    for (auto &a : comp->getActions()){
+    for (auto &a : comp->getActions()) {
       // On MacOSX real actions may end up being wrapped in BindArchAction
       if (isa<driver::BindArchAction>(a))
         a = *a->input_begin();

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -687,7 +687,7 @@ public:
   IndexDataConsumer(IndexParam &param) : param(param) {}
   void initialize(ASTContext &ctx) override { this->ctx = param.ctx = &ctx; }
 #if LLVM_VERSION_MAJOR < 10 // llvmorg-10-init-12036-g3b9715cb219
-# define handleDeclOccurrence handleDeclOccurence
+#  define handleDeclOccurrence handleDeclOccurence
 #endif
   bool handleDeclOccurrence(const Decl *d, index::SymbolRoleSet roles,
                             ArrayRef<index::SymbolRelation> relations,
@@ -885,10 +885,10 @@ public:
                 Usr usr1 = getUsr(d1, &info1);
                 IndexType &type1 = db->toType(usr1);
                 SourceLocation sl1 = d1->getLocation();
-                type1.def.spell = {
-                    Use{{fromTokenRange(sm, lang, {sl1, sl1}), Role::Definition},
-                        lid},
-                    fromTokenRange(sm, lang, sr1)};
+                type1.def.spell = {Use{{fromTokenRange(sm, lang, {sl1, sl1}),
+                                        Role::Definition},
+                                       lid},
+                                   fromTokenRange(sm, lang, sr1)};
                 type1.def.detailed_name = intern(info1->short_name);
                 type1.def.short_name_size = int16_t(info1->short_name.size());
                 type1.def.kind = SymbolKind::TypeParameter;
@@ -1208,7 +1208,7 @@ class IndexDiags : public DiagnosticConsumer {
 public:
   llvm::SmallString<64> message;
   void HandleDiagnostic(DiagnosticsEngine::Level level,
-    const clang::Diagnostic &info) override {
+                        const clang::Diagnostic &info) override {
     DiagnosticConsumer::HandleDiagnostic(level, info);
     if (message.empty())
       info.FormatDiagnostic(message);

--- a/src/lsp.hh
+++ b/src/lsp.hh
@@ -219,6 +219,17 @@ struct TextDocumentDidChangeParam {
   std::vector<TextDocumentContentChangeEvent> contentChanges;
 };
 
+struct WorkDoneProgress {
+  const char *kind;
+  std::optional<std::string> title;
+  std::optional<std::string> message;
+  std::optional<double> percentage;
+};
+struct WorkDoneProgressParam {
+  const char *token;
+  WorkDoneProgress value;
+};
+
 struct WorkspaceFolder {
   DocumentUri uri;
   std::string name;

--- a/src/message_handler.hh
+++ b/src/message_handler.hh
@@ -191,6 +191,8 @@ REFLECT_UNDERLYING_B(SymbolKind);
 REFLECT_STRUCT(TextDocumentIdentifier, uri);
 REFLECT_STRUCT(TextDocumentItem, uri, languageId, version, text);
 REFLECT_STRUCT(TextEdit, range, newText);
+REFLECT_STRUCT(WorkDoneProgress, kind, title, message, percentage);
+REFLECT_STRUCT(WorkDoneProgressParam, token, value);
 REFLECT_STRUCT(DiagnosticRelatedInformation, location, message);
 REFLECT_STRUCT(Diagnostic, range, severity, code, source, message,
                relatedInformation);

--- a/src/messages/ccls_info.cc
+++ b/src/messages/ccls_info.cc
@@ -17,14 +17,14 @@ struct Out_cclsInfo {
     int files, funcs, types, vars;
   } db;
   struct Pipeline {
-    int pendingIndexRequests;
+    int64_t lastIdle, completed, enqueued;
   } pipeline;
   struct Project {
     int entries;
   } project;
 };
 REFLECT_STRUCT(Out_cclsInfo::DB, files, funcs, types, vars);
-REFLECT_STRUCT(Out_cclsInfo::Pipeline, pendingIndexRequests);
+REFLECT_STRUCT(Out_cclsInfo::Pipeline, lastIdle, completed, enqueued);
 REFLECT_STRUCT(Out_cclsInfo::Project, entries);
 REFLECT_STRUCT(Out_cclsInfo, db, pipeline, project);
 } // namespace
@@ -35,7 +35,9 @@ void MessageHandler::ccls_info(EmptyParam &, ReplyOnce &reply) {
   result.db.funcs = db->funcs.size();
   result.db.types = db->types.size();
   result.db.vars = db->vars.size();
-  result.pipeline.pendingIndexRequests = pipeline::pending_index_requests;
+  result.pipeline.lastIdle = pipeline::stats.last_idle;
+  result.pipeline.completed = pipeline::stats.completed;
+  result.pipeline.enqueued = pipeline::stats.enqueued;
   result.project.entries = 0;
   for (auto &[_, folder] : project->root2folder)
     result.project.entries += folder.entries.size();

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -348,17 +348,16 @@ void do_initialize(MessageHandler *m, InitializeParam &param,
     std::string path = wf.uri.getPath();
     ensureEndsInSlash(path);
     std::string real = realPath(path) + '/';
-    workspaceFolders.emplace_back(path, path == real ? "" : real);
+    workspaceFolders.emplace_back(path, real);
   }
   if (workspaceFolders.empty()) {
     std::string real = realPath(project_path) + '/';
-    workspaceFolders.emplace_back(project_path,
-                                  project_path == real ? "" : real);
+    workspaceFolders.emplace_back(project_path, real);
   }
   std::sort(workspaceFolders.begin(), workspaceFolders.end(),
             [](auto &l, auto &r) { return l.first.size() > r.first.size(); });
   for (auto &[folder, real] : workspaceFolders)
-    if (real.empty())
+    if (real == folder)
       LOG_S(INFO) << "workspace folder: " << folder;
     else
       LOG_S(INFO) << "workspace folder: " << folder << " -> " << real;

--- a/src/messages/textDocument_did.cc
+++ b/src/messages/textDocument_did.cc
@@ -44,7 +44,7 @@ void MessageHandler::textDocument_didOpen(DidOpenTextDocumentParam &param) {
   // pending index request.
   auto [lang, header] = lookupExtension(path);
   if ((lang != LanguageId::Unknown && !header) ||
-      !pipeline::pending_index_requests)
+      pipeline::stats.completed == pipeline::stats.enqueued)
     pipeline::index(path, {}, IndexMode::Normal, false);
   if (header)
     project->indexRelated(path);

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -27,7 +27,7 @@
 #include <shared_mutex>
 #include <thread>
 #ifndef _WIN32
-#include <unistd.h>
+#  include <unistd.h>
 #endif
 using namespace llvm;
 namespace chrono = std::chrono;

--- a/src/pipeline.hh
+++ b/src/pipeline.hh
@@ -39,9 +39,14 @@ enum class IndexMode {
   Normal,
 };
 
+struct IndexStats {
+  std::atomic<int64_t> last_idle, completed, enqueued;
+};
+
 namespace pipeline {
 extern std::atomic<bool> g_quit;
-extern std::atomic<int64_t> loaded_ts, pending_index_requests;
+extern std::atomic<int64_t> loaded_ts;
+extern IndexStats stats;
 extern int64_t tick;
 
 void threadEnter();

--- a/src/platform_posix.cc
+++ b/src/platform_posix.cc
@@ -2,38 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if defined(__unix__) || defined(__APPLE__)
-#include "platform.hh"
+#  include "platform.hh"
 
-#include "utils.hh"
+#  include "utils.hh"
 
-#include <assert.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#  include <assert.h>
+#  include <limits.h>
+#  include <stdio.h>
+#  include <stdlib.h>
+#  include <string.h>
+#  include <time.h>
 
-#include <dirent.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <pthread.h>
-#include <signal.h>
-#include <sys/resource.h>
-#include <sys/stat.h>
-#include <sys/types.h> // required for stat.h
-#include <sys/wait.h>
-#include <unistd.h>
-#ifdef __GLIBC__
-#include <malloc.h>
-#endif
+#  include <dirent.h>
+#  include <errno.h>
+#  include <fcntl.h>
+#  include <pthread.h>
+#  include <signal.h>
+#  include <sys/resource.h>
+#  include <sys/stat.h>
+#  include <sys/types.h> // required for stat.h
+#  include <sys/wait.h>
+#  include <unistd.h>
+#  ifdef __GLIBC__
+#    include <malloc.h>
+#  endif
 
-#include <llvm/ADT/SmallString.h>
-#include <llvm/Support/Path.h>
+#  include <llvm/ADT/SmallString.h>
+#  include <llvm/Support/Path.h>
 
-#include <atomic>
-#include <condition_variable>
-#include <mutex>
-#include <string>
+#  include <atomic>
+#  include <condition_variable>
+#  include <mutex>
+#  include <string>
 
 namespace ccls {
 namespace pipeline {
@@ -47,9 +47,9 @@ std::string normalizePath(llvm::StringRef path) {
 }
 
 void freeUnusedMemory() {
-#ifdef __GLIBC__
+#  ifdef __GLIBC__
   malloc_trim(4 * 1024 * 1024);
-#endif
+#  endif
 }
 
 void traceMe() {

--- a/src/platform_win.cc
+++ b/src/platform_win.cc
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if defined(_WIN32)
-#include "platform.hh"
+#  include "platform.hh"
 
-#include "utils.hh"
+#  include "utils.hh"
 
-#include <Windows.h>
-#include <direct.h>
-#include <fcntl.h>
-#include <io.h>
+#  include <Windows.h>
+#  include <direct.h>
+#  include <fcntl.h>
+#  include <io.h>
 
-#include <sys/stat.h>
-#include <sys/types.h>
+#  include <sys/stat.h>
+#  include <sys/types.h>
 
-#include <algorithm>
-#include <string>
-#include <thread>
+#  include <algorithm>
+#  include <string>
+#  include <thread>
 
 namespace ccls {
 std::string normalizePath(llvm::StringRef path) {

--- a/src/project.cc
+++ b/src/project.cc
@@ -25,9 +25,9 @@
 #include <rapidjson/writer.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#  include <Windows.h>
 #else
-#include <unistd.h>
+#  include <unistd.h>
 #endif
 
 #include <array>

--- a/src/project.cc
+++ b/src/project.cc
@@ -433,7 +433,9 @@ void Project::loadDirectory(const std::string &root, Project::Folder &folder) {
       // If workspace folder is real/ but entries use symlink/, convert to
       // real/.
       entry.directory = realPath(cmd.Directory);
+      entry.directory.push_back('/');
       normalizeFolder(entry.directory);
+      entry.directory.pop_back();
       doPathMapping(entry.directory);
       entry.filename =
           realPath(resolveIfRelative(entry.directory, cmd.Filename));

--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -47,12 +47,12 @@ struct ProxyFileSystem : FileSystem {
   std::error_code setCurrentWorkingDirectory(const Twine &Path) override {
     return FS->setCurrentWorkingDirectory(Path);
   }
-#if LLVM_VERSION_MAJOR == 7
+#  if LLVM_VERSION_MAJOR == 7
   std::error_code getRealPath(const Twine &Path,
                               SmallVectorImpl<char> &Output) const override {
     return FS->getRealPath(Path, Output);
   }
-#endif
+#  endif
   FileSystem &getUnderlyingFS() { return *FS; }
   IntrusiveRefCntPtr<FileSystem> FS;
 };

--- a/src/test.cc
+++ b/src/test.cc
@@ -25,8 +25,8 @@
 
 // The 'diff' utility is available and we can use dprintf(3).
 #if _POSIX_C_SOURCE >= 200809L
-#include <sys/wait.h>
-#include <unistd.h>
+#  include <sys/wait.h>
+#  include <unistd.h>
 #endif
 
 using namespace llvm;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -138,11 +138,15 @@ std::string realPath(const std::string &path) {
 }
 
 bool normalizeFolder(std::string &path) {
-  for (auto &[root, real] : g_config->workspaceFolders)
-    if (real.size() && llvm::StringRef(path).startswith(real)) {
+  for (auto &[root, real] : g_config->workspaceFolders) {
+    StringRef p(path);
+    if (p.startswith(root))
+      return true;
+    if (p.startswith(real)) {
       path = root + path.substr(real.size());
       return true;
     }
+  }
   return false;
 }
 


### PR DESCRIPTION
I saw this style for pp directives in the code:
```cpp
#if LLVM_VERSION_MAJOR < 10 // llvmorg-10-init-12036-g3b9715cb219
#  define handleDeclOccurrence handleDeclOccurence
#endif
```

and there is an option for it in clang-format if you want, it also touches includes which looks weird?
I also ran clang-format on all files.

Or we can go with the default style but we have to run clang-format anyway because some files aren't formatted correctly (indexer.cc, clang_tu.cc).