### PR TITLE
Fix document symbol with a range based method (outline and breadcumbs)

### DIFF
--- a/src/messages/textDocument_document.cc
+++ b/src/messages/textDocument_document.cc
@@ -158,10 +158,13 @@ void MessageHandler::textDocument_documentSymbol(JsonReader &reader,
     /**
      * with 2 ranges that start at the same Position, we want the wider one
      * first (swap lhs/rhs)
+     *
+     * we use range for start to start at symbol name
+     * issue with: int i, j, k; otherwise
      */
     auto sym_cmp = [](ExtentRef const &lhs, ExtentRef const &rhs) {
-      return lhs.extent.start < rhs.extent.start ||
-             (lhs.extent.start == rhs.extent.start &&
+      return lhs.range.start < rhs.range.start ||
+             (lhs.range.start == rhs.range.start &&
               rhs.extent.end < lhs.extent.end);
     };
 
@@ -197,7 +200,10 @@ void MessageHandler::textDocument_documentSymbol(JsonReader &reader,
 
         if (!ignore(def) && (ds.kind == SymbolKind::Namespace || allows(sym))) {
           // drop symbols that are behind the current one
-          while (!indent.empty() && indent.top()->range.end < ds.range.start) {
+          while (!indent.empty() &&
+                 // use selectionRange for start to start at symbol name
+                 // issue with: int i, j, k; otherwise
+                 indent.top()->range.end < ds.selectionRange.start) {
             indent.pop();
           }
           if (indent.empty()) {


### PR DESCRIPTION
**This is an alternative to https://github.com/MaskRay/ccls/pull/660, I have redone all the algorithm for hierarchical document symbol, it is based on ranges of symbols and not on symbols and their children because some of them were missing and "duplicates" were removed (eg: namespace redefinition in the same file, or inline function defined after the class)** 

When we have members defined outside the class in a namespace in a separate file, the namespace doesn't have the members as children. The outline and breadcrumbs don't work correctly for them.
Before:
![Screenshot_20200702_214411](https://user-images.githubusercontent.com/24270152/86407323-1ffd0700-bcb5-11ea-8673-fa72fd87b9b8.png)
After:
![Screenshot_20200702_213950](https://user-images.githubusercontent.com/24270152/86407361-330fd700-bcb5-11ea-82b9-d96d9a463180.png)

There are other bugs with outline that I noticed which I am working on:
- [x] static member variable aren't in their class/struct
- [x] defined member functions after the class definition in the same file override the member function declaration
- [x] inline namespace