### PR TITLE
Allow relative path for directory

### DIFF
--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -111,7 +111,11 @@ buildCompilerInvocation(const std::string &main, std::vector<const char *> args,
   IntrusiveRefCntPtr<DiagnosticsEngine> diags(
       CompilerInstance::createDiagnostics(new DiagnosticOptions,
                                           new IgnoringDiagConsumer, true));
+#if LLVM_VERSION_MAJOR < 12 // llvmorg-12-init-5498-g257b29715bb
   driver::Driver d(args[0], llvm::sys::getDefaultTargetTriple(), *diags, vfs);
+#else
+  driver::Driver d(args[0], llvm::sys::getDefaultTargetTriple(), *diags, "ccls", vfs);
+#endif
   d.setCheckInputsExist(false);
   std::unique_ptr<driver::Compilation> comp(d.BuildCompilation(args));
   if (!comp)

--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -152,6 +152,10 @@ buildCompilerInvocation(const std::string &main, std::vector<const char *> args,
   // Enable IndexFrontendAction::shouldSkipFunctionBody.
   ci->getFrontendOpts().SkipFunctionBodies = true;
   ci->getLangOpts()->SpellChecking = false;
+#if LLVM_VERSION_MAJOR >= 11
+  ci->getLangOpts()->RecoveryAST = true;
+  ci->getLangOpts()->RecoveryASTType = true;
+#endif
   auto &isec = ci->getFrontendOpts().Inputs;
   if (isec.size())
     isec[0] = FrontendInputFile(main, isec[0].getKind(), isec[0].isSystem());

--- a/src/project.cc
+++ b/src/project.cc
@@ -432,7 +432,8 @@ void Project::loadDirectory(const std::string &root, Project::Folder &folder) {
 
       // If workspace folder is real/ but entries use symlink/, convert to
       // real/.
-      entry.directory = realPath(cmd.Directory);
+      entry.directory =
+          realPath(resolveIfRelative(cdbDir.c_str(), cmd.Directory));
       entry.directory.push_back('/');
       normalizeFolder(entry.directory);
       entry.directory.pop_back();

--- a/src/project.cc
+++ b/src/project.cc
@@ -523,7 +523,7 @@ Project::Entry Project::findEntry(const std::string &path, bool can_redirect,
         if (it != folder.path2entry_index.end()) {
           Project::Entry &entry = folder.entries[it->second];
           exact_match = entry.filename == path;
-          if ((match = exact_match || can_redirect) || entry.compdb_size) {
+          if ((match = exact_match || can_redirect) && entry.compdb_size) {
             // best->compdb_size is >0 for a compdb entry, 0 for a .ccls entry.
             best_compdb_folder = &folder;
             best = &entry;
@@ -533,8 +533,9 @@ Project::Entry Project::findEntry(const std::string &path, bool can_redirect,
     }
 
   bool append = false;
-  if (best_dot_ccls_args && !(append = appendToCDB(*best_dot_ccls_args)) &&
-      !exact_match) {
+  if (best_dot_ccls_args &&
+      (!best_compdb_folder ||
+       (!(append = appendToCDB(*best_dot_ccls_args)) && !exact_match))) {
     // If the first line is not %compile_commands.json, override the compdb
     // match if it is not an exact match.
     ret.root = ret.directory = best_dot_ccls_root;


### PR DESCRIPTION
directory in _compiler_commands.json_
If the value is relative we resolve it from the root

This will help in VS Code integration. We open the root folder in **VS Code** and the directory value can be specified as related to the root folder. Thus the _compile_commnads.json_ can be committed to the code repository rather than having to build it every time code is pulled.