### PR TITLE
Add -m64 to gcc by default on illumos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,23 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
   target_link_libraries(ccls PRIVATE thr)
 endif()
 
+if (${CMAKE_SYSTEM_NAME} STREQUAL SunOS)
+  # Check if we are on illumos
+  execute_process(COMMAND /usr/bin/uname -o OUTPUT_VARIABLE UNAME_O
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if ((UNAME_O STREQUAL illumos) AND (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU))
+    # As a workaround for legacy packages, illumos' GCC generates 32-bit object files
+    # despite 32-bit platform support has already been dropped. This will probably cause a linker error
+    # since most distros seem to supply 64-bit LLVM in their repositories
+    # (verified on OpenIndiana and OmniOS).
+    # Add -m64 on illumos with GCC by default to generate 64-bit object files.
+    option(ILLUMOS_USE_M64 "Use -m64 on illumos to generate 64-bit object files" ON)
+    if (ILLUMOS_USE_M64)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
+    endif()
+  endif()
+endif()
+
 if(LLVM_ENABLE_ZLIB)
   find_package(ZLIB)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,10 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
   target_link_libraries(ccls PRIVATE thr)
 endif()
 
+if(LLVM_ENABLE_ZLIB)
+  find_package(ZLIB)
+endif()
+
 ### Definitions
 
 # Find Clang resource directory with Clang executable.

--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -155,6 +155,9 @@ buildCompilerInvocation(const std::string &main, std::vector<const char *> args,
   auto &isec = ci->getFrontendOpts().Inputs;
   if (isec.size())
     isec[0] = FrontendInputFile(main, isec[0].getKind(), isec[0].isSystem());
+#if LLVM_VERSION_MAJOR >= 10 // llvmorg-11-init-2414-g75f09b54429
+  ci->getPreprocessorOpts().DisablePragmaDebugCrash = true;
+#endif
   // clangSerialization has an unstable format. Disable PCH reading/writing
   // to work around PCH mismatch problems.
   ci->getPreprocessorOpts().ImplicitPCHInclude.clear();

--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -111,7 +111,11 @@ buildCompilerInvocation(const std::string &main, std::vector<const char *> args,
   IntrusiveRefCntPtr<DiagnosticsEngine> diags(
       CompilerInstance::createDiagnostics(new DiagnosticOptions,
                                           new IgnoringDiagConsumer, true));
+#if LLVM_VERSION_MAJOR < 12 // llvmorg-12-init-5498-g257b29715bb
   driver::Driver d(args[0], llvm::sys::getDefaultTargetTriple(), *diags, vfs);
+#else
+  driver::Driver d(args[0], llvm::sys::getDefaultTargetTriple(), *diags, "ccls", vfs);
+#endif
   d.setCheckInputsExist(false);
   std::unique_ptr<driver::Compilation> comp(d.BuildCompilation(args));
   if (!comp)

--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -152,6 +152,10 @@ buildCompilerInvocation(const std::string &main, std::vector<const char *> args,
   // Enable IndexFrontendAction::shouldSkipFunctionBody.
   ci->getFrontendOpts().SkipFunctionBodies = true;
   ci->getLangOpts()->SpellChecking = false;
+#if LLVM_VERSION_MAJOR >= 11
+  ci->getLangOpts()->RecoveryAST = true;
+  ci->getLangOpts()->RecoveryASTType = true;
+#endif
   auto &isec = ci->getFrontendOpts().Inputs;
   if (isec.size())
     isec[0] = FrontendInputFile(main, isec[0].getKind(), isec[0].isSystem());

--- a/src/lsp.hh
+++ b/src/lsp.hh
@@ -219,6 +219,17 @@ struct TextDocumentDidChangeParam {
   std::vector<TextDocumentContentChangeEvent> contentChanges;
 };
 
+struct WorkDoneProgress {
+  const char *kind;
+  std::optional<std::string> title;
+  std::optional<std::string> message;
+  std::optional<double> percentage;
+};
+struct WorkDoneProgressParam {
+  const char *token;
+  WorkDoneProgress value;
+};
+
 struct WorkspaceFolder {
   DocumentUri uri;
   std::string name;

--- a/src/message_handler.hh
+++ b/src/message_handler.hh
@@ -191,6 +191,8 @@ REFLECT_UNDERLYING_B(SymbolKind);
 REFLECT_STRUCT(TextDocumentIdentifier, uri);
 REFLECT_STRUCT(TextDocumentItem, uri, languageId, version, text);
 REFLECT_STRUCT(TextEdit, range, newText);
+REFLECT_STRUCT(WorkDoneProgress, kind, title, message, percentage);
+REFLECT_STRUCT(WorkDoneProgressParam, token, value);
 REFLECT_STRUCT(DiagnosticRelatedInformation, location, message);
 REFLECT_STRUCT(Diagnostic, range, severity, code, source, message,
                relatedInformation);

--- a/src/messages/ccls_info.cc
+++ b/src/messages/ccls_info.cc
@@ -17,14 +17,14 @@ struct Out_cclsInfo {
     int files, funcs, types, vars;
   } db;
   struct Pipeline {
-    int pendingIndexRequests;
+    int64_t lastIdle, completed, enqueued;
   } pipeline;
   struct Project {
     int entries;
   } project;
 };
 REFLECT_STRUCT(Out_cclsInfo::DB, files, funcs, types, vars);
-REFLECT_STRUCT(Out_cclsInfo::Pipeline, pendingIndexRequests);
+REFLECT_STRUCT(Out_cclsInfo::Pipeline, lastIdle, completed, enqueued);
 REFLECT_STRUCT(Out_cclsInfo::Project, entries);
 REFLECT_STRUCT(Out_cclsInfo, db, pipeline, project);
 } // namespace
@@ -35,7 +35,9 @@ void MessageHandler::ccls_info(EmptyParam &, ReplyOnce &reply) {
   result.db.funcs = db->funcs.size();
   result.db.types = db->types.size();
   result.db.vars = db->vars.size();
-  result.pipeline.pendingIndexRequests = pipeline::pending_index_requests;
+  result.pipeline.lastIdle = pipeline::stats.last_idle;
+  result.pipeline.completed = pipeline::stats.completed;
+  result.pipeline.enqueued = pipeline::stats.enqueued;
   result.project.entries = 0;
   for (auto &[_, folder] : project->root2folder)
     result.project.entries += folder.entries.size();

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -348,17 +348,16 @@ void do_initialize(MessageHandler *m, InitializeParam &param,
     std::string path = wf.uri.getPath();
     ensureEndsInSlash(path);
     std::string real = realPath(path) + '/';
-    workspaceFolders.emplace_back(path, path == real ? "" : real);
+    workspaceFolders.emplace_back(path, real);
   }
   if (workspaceFolders.empty()) {
     std::string real = realPath(project_path) + '/';
-    workspaceFolders.emplace_back(project_path,
-                                  project_path == real ? "" : real);
+    workspaceFolders.emplace_back(project_path, real);
   }
   std::sort(workspaceFolders.begin(), workspaceFolders.end(),
             [](auto &l, auto &r) { return l.first.size() > r.first.size(); });
   for (auto &[folder, real] : workspaceFolders)
-    if (real.empty())
+    if (real == folder)
       LOG_S(INFO) << "workspace folder: " << folder;
     else
       LOG_S(INFO) << "workspace folder: " << folder << " -> " << real;

--- a/src/messages/textDocument_did.cc
+++ b/src/messages/textDocument_did.cc
@@ -44,7 +44,7 @@ void MessageHandler::textDocument_didOpen(DidOpenTextDocumentParam &param) {
   // pending index request.
   auto [lang, header] = lookupExtension(path);
   if ((lang != LanguageId::Unknown && !header) ||
-      !pipeline::pending_index_requests)
+      pipeline::stats.completed == pipeline::stats.enqueued)
     pipeline::index(path, {}, IndexMode::Normal, false);
   if (header)
     project->indexRelated(path);

--- a/src/pipeline.hh
+++ b/src/pipeline.hh
@@ -39,9 +39,14 @@ enum class IndexMode {
   Normal,
 };
 
+struct IndexStats {
+  std::atomic<int64_t> last_idle, completed, enqueued;
+};
+
 namespace pipeline {
 extern std::atomic<bool> g_quit;
-extern std::atomic<int64_t> loaded_ts, pending_index_requests;
+extern std::atomic<int64_t> loaded_ts;
+extern IndexStats stats;
 extern int64_t tick;
 
 void threadEnter();

--- a/src/project.cc
+++ b/src/project.cc
@@ -522,9 +522,10 @@ Project::Entry Project::findEntry(const std::string &path, bool can_redirect,
         auto it = folder.path2entry_index.find(path);
         if (it != folder.path2entry_index.end()) {
           Project::Entry &entry = folder.entries[it->second];
-          exact_match = entry.filename == path;
-          if ((match = exact_match || can_redirect) || entry.compdb_size) {
-            // best->compdb_size is >0 for a compdb entry, 0 for a .ccls entry.
+          // best->compdb_size is >0 for an explicit compile_commands.json
+          // entry, 0 for an implicit entry.
+          exact_match = entry.compdb_size > 0 && entry.filename == path;
+          if ((match = exact_match || can_redirect) && entry.compdb_size) {
             best_compdb_folder = &folder;
             best = &entry;
           }

--- a/src/project.cc
+++ b/src/project.cc
@@ -433,7 +433,9 @@ void Project::loadDirectory(const std::string &root, Project::Folder &folder) {
       // If workspace folder is real/ but entries use symlink/, convert to
       // real/.
       entry.directory = realPath(cmd.Directory);
+      entry.directory.push_back('/');
       normalizeFolder(entry.directory);
+      entry.directory.pop_back();
       doPathMapping(entry.directory);
       entry.filename =
           realPath(resolveIfRelative(entry.directory, cmd.Filename));

--- a/src/project.cc
+++ b/src/project.cc
@@ -252,7 +252,7 @@ void loadDirectoryListing(ProjectProcessor &proc, const std::string &root,
 
   auto getDotCcls = [&root, &folder](std::string cur) {
     while (!(cur = sys::path::parent_path(cur)).empty()) {
-      auto it = folder.dot_ccls.find(cur);
+      auto it = folder.dot_ccls.find(cur + '/');
       if (it != folder.dot_ccls.end())
         return it->second;
       std::string normalized = normalizePath(cur);

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -138,11 +138,15 @@ std::string realPath(const std::string &path) {
 }
 
 bool normalizeFolder(std::string &path) {
-  for (auto &[root, real] : g_config->workspaceFolders)
-    if (real.size() && llvm::StringRef(path).startswith(real)) {
+  for (auto &[root, real] : g_config->workspaceFolders) {
+    StringRef p(path);
+    if (p.startswith(root))
+      return true;
+    if (p.startswith(real)) {
       path = root + path.substr(real.size());
       return true;
     }
+  }
   return false;
 }
 


### PR DESCRIPTION
GCC on illumos generates 32-bit object files by default to maintain
backward compatibility, despite 32-bit platforms are no longer
supported. This may cause link errors, since most distros seem to supply
64-bit LLVM in their repositories (verified on OpenIndiana and OmniOS).
This commit adds an ILLUMOS_USE_M64 option, which is turned on by
default, to instruct gcc on illumos to generate 64-bit object files, as
this is usually the desired behaviour.