### PR TITLE
Making the progress an integer, as per the specification.

### DIFF
--- a/src/lsp.hh
+++ b/src/lsp.hh
@@ -223,7 +223,7 @@ struct WorkDoneProgress {
   const char *kind;
   std::optional<std::string> title;
   std::optional<std::string> message;
-  std::optional<double> percentage;
+  std::optional<int> percentage;
 };
 struct WorkDoneProgressParam {
   const char *token;

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -729,7 +729,7 @@ void mainLoop() {
             (Twine(completed - last_idle) + "/" + Twine(enqueued - last_idle))
                 .str();
         param.value.percentage =
-            100.0 * (completed - last_idle) / (enqueued - last_idle);
+            100 * (completed - last_idle) / (enqueued - last_idle);
         notify("$/progress", param);
       } else if (in_progress) {
         stats.last_idle.store(enqueued, std::memory_order_relaxed);


### PR DESCRIPTION
My understanding of the WorkDoneProgressReport is that the percentage should be an (unsigned) integer, not a floating point numer:
https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workDoneProgressReport

Trying to fix that here. Please let me know what you think.