### PR TITLE
Initialization Option: completion.overwriteFollowingIdentifier

### DIFF
--- a/src/config.hh
+++ b/src/config.hh
@@ -166,6 +166,11 @@ struct Config {
     // that implement their own filtering and sorting logic.
     bool filterAndSort = true;
 
+    // Decides whether to overwrite the identifier following cursor.
+    // true -- overwrite the following identifier.
+    // false -- insert completion before the following identifier.
+    bool overwriteFollowingIdentifier = true;
+
     struct Include {
       // Regex patterns to match include completion candidates against. They
       // receive the absolute file path.
@@ -338,8 +343,8 @@ REFLECT_STRUCT(Config::CodeLens, localVariables);
 REFLECT_STRUCT(Config::Completion::Include, blacklist, maxPathSize,
                suffixWhitelist, whitelist);
 REFLECT_STRUCT(Config::Completion, caseSensitivity, detailedLabel,
-               dropOldRequests, duplicateOptional, filterAndSort, include,
-               maxNum, placeholder);
+               dropOldRequests, duplicateOptional, filterAndSort,
+               overwriteFollowingIdentifier, include, maxNum, placeholder);
 REFLECT_STRUCT(Config::Diagnostics, blacklist, onChange, onOpen, onSave,
                spellChecking, whitelist)
 REFLECT_STRUCT(Config::Highlight, largeFileSize, lsRanges, blacklist, whitelist)

--- a/src/working_files.cc
+++ b/src/working_files.cc
@@ -347,9 +347,12 @@ Position WorkingFile::getCompletionPosition(Position pos, std::string *filter,
     --i;
 
   *replace_end_pos = pos;
-  for (int i = start;
-       i < buffer_content.size() && isIdentifierBody(buffer_content[i]); i++)
-    replace_end_pos->character++;
+  if (g_config->completion.overwriteFollowingIdentifier) {
+    // attempt to overwrite the following identifier
+    for (int i = start;
+         i < buffer_content.size() && isIdentifierBody(buffer_content[i]); i++)
+      replace_end_pos->character++;
+  }
 
   *filter = buffer_content.substr(i, start - i);
   return getPositionForOffset(buffer_content, i);


### PR DESCRIPTION
Previously, ccls overwrites the identifier immediately following the
cursor on completions. Some user does not want this behaviour.

This commit introduces a new initialization option:
completion.overwriteFollowingIdentifier, which allows
customizing the said behaviour.

fix #678.