### PR TITLE
Make llvm::StringRef to std::string conversions explicit.

### DIFF
--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -25,7 +25,7 @@ std::string pathFromFileEntry(const FileEntry &file) {
     // Resolve symlinks outside of working folders. This handles leading path
     // components, e.g. (/lib -> /usr/lib) in
     // /../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/utility
-    ret = file.tryGetRealPathName();
+    ret = std::string(file.tryGetRealPathName());
   } else {
     // If getName() refers to a file within a workspace folder, we prefer it
     // (which may be a symlink).

--- a/src/messages/workspace.cc
+++ b/src/messages/workspace.cc
@@ -38,7 +38,7 @@ void MessageHandler::workspace_didChangeWatchedFiles(
          StringRef(path).startswith(g_config->cache.directory)) ||
         lookupExtension(path).first == LanguageId::Unknown)
       return;
-    for (std::string cur = path; cur.size(); cur = sys::path::parent_path(cur))
+    for (std::string cur = path; cur.size(); cur = std::string(sys::path::parent_path(cur)))
       if (cur[0] == '.')
         return;
 

--- a/src/project.cc
+++ b/src/project.cc
@@ -251,7 +251,7 @@ void loadDirectoryListing(ProjectProcessor &proc, const std::string &root,
   std::vector<std::string> files;
 
   auto getDotCcls = [&root, &folder](std::string cur) {
-    while (!(cur = sys::path::parent_path(cur)).empty()) {
+    while (!(cur = std::string(sys::path::parent_path(cur))).empty()) {
       auto it = folder.dot_ccls.find(cur + '/');
       if (it != folder.dot_ccls.end())
         return it->second;

--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -249,9 +249,9 @@ public:
       info.FormatDiagnostic(message);
       d.range =
           fromCharSourceRange(sm, *langOpts, diagnosticRange(info, *langOpts));
-      d.message = message.str();
+      d.message = std::string(message.str());
       d.concerned = concerned;
-      d.file = filename;
+      d.file = std::string(filename);
       d.level = level;
       d.category = DiagnosticIDs::getCategoryNumberForDiag(info.getID());
     };


### PR DESCRIPTION
The implicit convertion can not be compiled in win10, llvm 11.0, msvc 2019.
Same issue there: #720 
