### PR TITLE
Fix compile error when use msvc 2019

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ if(MSVC)
     /wd4800
     /wd4068 # Disable unknown pragma warning
     /std:c++17
+    /Zc:__cplusplus
     $<$<CONFIG:Debug>:/FS>
   )
   # relink system libs


### PR DESCRIPTION
#747 This error is not conversion problem. it need a `__cplusplus` switch  and `/std:c++17` switch ,the value will equal to `201703L`.
Thanx @anurag-23
There is more information: https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/