### PR TITLE
Workaround inconsistency in intersection between ranges.

### DIFF
--- a/src/lsp.hh
+++ b/src/lsp.hh
@@ -100,7 +100,7 @@ struct lsRange {
     return start <= o.start && o.end <= end;
   }
   bool intersects(const lsRange &o) const {
-    return start < o.end && o.start < end;
+    return start <= o.end && o.start <= end;
   }
 };
 


### PR DESCRIPTION
Sadly there is some confusion about ranges in the LSP protocol. It turns out
that VS code, when requesting code actions, sends range s,e in the request,
with the associated meaning that e is _included_ in the range, i.e. the interval
is [s,e]. The emacs lsp-mode also uses this convention.

However, the protocl specifies that the end in the range s,e should not be part
of the interval, i.e. s,e is supposed to correspond to [s,e[:

https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#range

This was brought up with emacs-lsp, where the maintainer stated that he prefers
to stay compatbile with VS code rather than the protocol, and that the protocol
should likely be amended:

https://github.com/emacs-lsp/lsp-mode/issues/3144

If that is the case, ccls intersection between ranges should be amended for now,
such that the end parameter is part of the range.