### PR TITLE
feat: Add option CLANG_LINK_DYLIB for static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,8 @@ endif()
 
 find_package(Clang REQUIRED)
 
-if(CLANG_LINK_CLANG_DYLIB)
+option(CLANG_LINK_DYLIB ${CLANG_LINK_CLANG_DYLIB})
+if(CLANG_LINK_DYLIB)
   target_link_libraries(ccls PRIVATE clang-cpp)
 else()
   target_link_libraries(ccls PRIVATE


### PR DESCRIPTION
Hi, friend.

Clang provides CLANG_LINK_CLANG_DYLIB variable. But it is not a option, it means I can't change it by -DCLANG_LINK_CLANG_DYLIB=OFF.

I had try make CLANG_LINK_CLANG_DYLIB as a options, but policy CMP0077 get warnings, so I create a new option CLANG_LINK_DYLIB to do this.