### PR TITLE
Help Clang find bottom of stacks for safety, use desired stack size

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -8,6 +8,7 @@
 #include "test.hh"
 #include "working_files.hh"
 
+#include <clang/Basic/Stack.h>
 #include <clang/Basic/Version.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/CrashRecoveryContext.h>
@@ -78,8 +79,12 @@ int main(int argc, char **argv) {
 
   pipeline::init();
   const char *env = getenv("CCLS_CRASH_RECOVERY");
-  if (!env || strcmp(env, "0") != 0)
+  if (!env || strcmp(env, "0") != 0) {
     CrashRecoveryContext::Enable();
+#if LLVM_VERSION_MAJOR >= 10    // rL369940
+    clang::noteBottomOfStack(); // per-thread, needed to avoid stack exhaustion
+#endif
+  }
 
   bool language_server = true;
 


### PR DESCRIPTION
noteBottomOfStack:

Without this, checks against stack space within Clang don't work as
Clang doesn't know where the stack begins.

Needed per-thread, as early as possible.
(on threads using Clang)


Using Clang's desired stack size:

Additionally increase stack size of pthreads to Clang's desired size.

This is presently 8MB, and is used by Clang's stack management
mechanisms to check* if close to stack exhaustion when determining if
there's sufficient space (and warn or run on a new thread with more).
(see runWithSufficientStackSpace)

The constant is available in LLVM 7 onwards.

* (abs(cur - bottom) > DesiredStackSize - threshold)