### PR TITLE
fix std::optional -> llvm::Optional for up-to-date upstream llvm 16.0.0.

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1097,7 +1097,9 @@ public:
   void InclusionDirective(SourceLocation hashLoc, const Token &tok,
                           StringRef included, bool isAngled,
                           CharSourceRange filenameRange,
-#if LLVM_VERSION_MAJOR >= 15 // llvmorg-15-init-7692-gd79ad2f1dbc2
+#if LLVM_VERSION_MAJOR >= 16 // llvmorg-16-init-14884-g8f0df9f3bbc6
+                          std::optional<FileEntryRef> fileRef,
+#elif LLVM_VERSION_MAJOR >= 15 // llvmorg-15-init-7692-gd79ad2f1dbc2
                           llvm::Optional<FileEntryRef> fileRef,
 #else
                           const FileEntry *file,

--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -1098,7 +1098,7 @@ public:
                           StringRef included, bool isAngled,
                           CharSourceRange filenameRange,
 #if LLVM_VERSION_MAJOR >= 16 // llvmorg-16-init-14884-g8f0df9f3bbc6
-                          std::optional<FileEntryRef> fileRef,
+                          llvm::Optional<FileEntryRef> fileRef,
 #elif LLVM_VERSION_MAJOR >= 15 // llvmorg-15-init-7692-gd79ad2f1dbc2
                           llvm::Optional<FileEntryRef> fileRef,
 #else

--- a/src/project.cc
+++ b/src/project.cc
@@ -391,11 +391,14 @@ void Project::loadDirectory(const std::string &root, Project::Folder &folder) {
       fwrite(input.c_str(), input.size(), 1, fout);
       fclose(fout);
     }
-    std::array<Optional<StringRef>, 3> redir{StringRef(stdinPath),
-                                             StringRef(path), StringRef()};
+#if LLVM_VERSION_MAJOR >= 16 // llvmorg-16-init-12589-ge748db0f7f09
+    std::array<std::optional<StringRef>, 3>
+#else
+    std::array<Optional<StringRef>, 3>
+#endif
+        redir{StringRef(stdinPath), StringRef(path), StringRef()};
     std::vector<StringRef> args{g_config->compilationDatabaseCommand, root};
-    if (sys::ExecuteAndWait(args[0], args, llvm::None, redir, 0, 0, &err_msg) <
-        0) {
+    if (sys::ExecuteAndWait(args[0], args, {}, redir, 0, 0, &err_msg) < 0) {
       LOG_S(ERROR) << "failed to execute " << args[0].str() << " "
                    << args[1].str() << ": " << err_msg;
       return;

--- a/src/project.cc
+++ b/src/project.cc
@@ -392,7 +392,7 @@ void Project::loadDirectory(const std::string &root, Project::Folder &folder) {
       fclose(fout);
     }
 #if LLVM_VERSION_MAJOR >= 16 // llvmorg-16-init-12589-ge748db0f7f09
-    std::array<std::optional<StringRef>, 3>
+    std::array<Optional<StringRef>, 3>
 #else
     std::array<Optional<StringRef>, 3>
 #endif

--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -180,7 +180,7 @@ public:
                           StringRef fileName, bool isAngled,
                           CharSourceRange filenameRange,
 #if LLVM_VERSION_MAJOR >= 16 // llvmorg-16-init-14884-g8f0df9f3bbc6
-                          std::optional<FileEntryRef> fileRef,
+                          llvm::Optional<FileEntryRef> fileRef,
 #elif LLVM_VERSION_MAJOR >= 15 // llvmorg-15-init-7692-gd79ad2f1dbc2
                           llvm::Optional<FileEntryRef> fileRef,
 #else

--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -179,7 +179,9 @@ public:
   void InclusionDirective(SourceLocation hashLoc, const Token &includeTok,
                           StringRef fileName, bool isAngled,
                           CharSourceRange filenameRange,
-#if LLVM_VERSION_MAJOR >= 15 // llvmorg-15-init-7692-gd79ad2f1dbc2
+#if LLVM_VERSION_MAJOR >= 16 // llvmorg-16-init-14884-g8f0df9f3bbc6
+                          std::optional<FileEntryRef> fileRef,
+#elif LLVM_VERSION_MAJOR >= 15 // llvmorg-15-init-7692-gd79ad2f1dbc2
                           llvm::Optional<FileEntryRef> fileRef,
 #else
                           const FileEntry *file,


### PR DESCRIPTION
The upstream llvm seemed using llvm::Optional instead of std::optional for several apis.