### PR TITLE
[SEMA_MANAGER] fix missing PrecompiledPreamble::Build parameter

### DIFF
--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -405,7 +405,7 @@ void buildPreamble(Session &session, CompilerInvocation &ci,
 
   CclsPreambleCallbacks pc;
   if (auto newPreamble = PrecompiledPreamble::Build(ci, buf.get(), bounds, *de, fs, session.pch, true,
-						    #if CINDEX_VERSION_MAJOR >= 0 && CINDEX_VERSION_MINOR > 63
+						    #if CINDEX_VERSION_MAJOR > 0 || CINDEX_VERSION_MINOR > 63
 						    "",
 						    #endif
 						    pc)) {

--- a/src/sema_manager.cc
+++ b/src/sema_manager.cc
@@ -17,6 +17,7 @@
 #include <llvm/Config/llvm-config.h>
 #include <llvm/Support/CrashRecoveryContext.h>
 #include <llvm/Support/Threading.h>
+#include <clang-c/Index.h>
 using namespace clang;
 using namespace llvm;
 
@@ -403,8 +404,11 @@ void buildPreamble(Session &session, CompilerInvocation &ci,
   }
 
   CclsPreambleCallbacks pc;
-  if (auto newPreamble = PrecompiledPreamble::Build(
-          ci, buf.get(), bounds, *de, fs, session.pch, true, pc)) {
+  if (auto newPreamble = PrecompiledPreamble::Build(ci, buf.get(), bounds, *de, fs, session.pch, true,
+						    #if CINDEX_VERSION_MAJOR >= 0 && CINDEX_VERSION_MINOR > 63
+						    "",
+						    #endif
+						    pc)) {
     assert(!ci.getPreprocessorOpts().RetainRemappedFileBuffers);
     if (oldP) {
       auto &old_includes = oldP->includes;


### PR DESCRIPTION
since llvm commit cc929590ad305f0d068709c7c7999f5fc6118dc9 (CommitDate: Tue Mar 7 08:25:38 2023 -0500) PrecompiledPreamble::Build() has an additional parameter for the default temporary path.

This introduced change breaks the ccls Build. This commit fixes it by checking the CINDEX_VERSION_MAJOR and CINDEX_VERSION_MINOR, and if the version is above 0.63 adds this path to nothing, which bahaves as the previous version according to the code commets.

This is kind of ugly but I don't know a cleaner solution.