### PR TITLE
utils: Add `<cstdint>`

### DIFF
--- a/src/utils.hh
+++ b/src/utils.hh
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string_view>
 
+#include <cstdint>
 #include <iterator>
 #include <memory>
 #include <string>


### PR DESCRIPTION
utils uses `uint64_t` without including `<cstdint>` which fails to build w/ GCC 15 after a change in libstdc++ [0]

[0] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2