### PR TITLE
Support LSP semantic tokens

### DIFF
--- a/src/config.hh
+++ b/src/config.hh
@@ -117,6 +117,8 @@ struct Config {
     bool hierarchicalDocumentSymbolSupport = true;
     // TextDocumentClientCapabilities.definition.linkSupport
     bool linkSupport = true;
+    // ClientCapabilities.workspace.semanticTokens.refreshSupport
+    bool semanticTokensRefresh = true;
 
     // If false, disable snippets and complete just the identifier part.
     // TextDocumentClientCapabilities.completion.completionItem.snippetSupport
@@ -226,8 +228,9 @@ struct Config {
     // Disable semantic highlighting for files larger than the size.
     int64_t largeFileSize = 2 * 1024 * 1024;
 
-    // true: LSP line/character; false: position
-    bool lsRanges = false;
+    // If non-zero, enable rainbow semantic tokens by assinging an extra modifier
+    // indicating the rainbow ID to each symbol.
+    int rainbow = 0;
 
     // Like index.{whitelist,blacklist}, don't publish semantic highlighting to
     // blacklisted files.
@@ -342,7 +345,7 @@ REFLECT_STRUCT(Config::Completion, caseSensitivity, detailedLabel,
                maxNum, placeholder);
 REFLECT_STRUCT(Config::Diagnostics, blacklist, onChange, onOpen, onSave,
                spellChecking, whitelist)
-REFLECT_STRUCT(Config::Highlight, largeFileSize, lsRanges, blacklist, whitelist)
+REFLECT_STRUCT(Config::Highlight, largeFileSize, rainbow, blacklist, whitelist)
 REFLECT_STRUCT(Config::Index::Name, suppressUnwrittenScope);
 REFLECT_STRUCT(Config::Index, blacklist, comments, initialNoLinkage,
                initialBlacklist, initialWhitelist, maxInitializerLines,

--- a/src/enum.inc
+++ b/src/enum.inc
@@ -1,0 +1,36 @@
+#ifndef TOKEN_MODIFIER
+#define TOKEN_MODIFIER(name, str)
+#endif
+// vscode
+TOKEN_MODIFIER(Declaration, "declaration")
+TOKEN_MODIFIER(Definition, "definition")
+TOKEN_MODIFIER(Static, "static")
+
+// ccls extensions
+TOKEN_MODIFIER(Read, "read")
+TOKEN_MODIFIER(Write, "write")
+TOKEN_MODIFIER(ClassScope, "classScope")
+TOKEN_MODIFIER(FunctionScope, "functionScope")
+TOKEN_MODIFIER(NamespaceScope, "namespaceScope")
+
+// Rainbow semantic tokens
+TOKEN_MODIFIER(Id0, "id0")
+TOKEN_MODIFIER(Id1, "id1")
+TOKEN_MODIFIER(Id2, "id2")
+TOKEN_MODIFIER(Id3, "id3")
+TOKEN_MODIFIER(Id4, "id4")
+TOKEN_MODIFIER(Id5, "id5")
+TOKEN_MODIFIER(Id6, "id6")
+TOKEN_MODIFIER(Id7, "id7")
+TOKEN_MODIFIER(Id8, "id8")
+TOKEN_MODIFIER(Id9, "id9")
+TOKEN_MODIFIER(Id10, "id10")
+TOKEN_MODIFIER(Id11, "id11")
+TOKEN_MODIFIER(Id12, "id12")
+TOKEN_MODIFIER(Id13, "id13")
+TOKEN_MODIFIER(Id14, "id14")
+TOKEN_MODIFIER(Id15, "id15")
+TOKEN_MODIFIER(Id16, "id16")
+TOKEN_MODIFIER(Id17, "id17")
+TOKEN_MODIFIER(Id18, "id18")
+TOKEN_MODIFIER(Id19, "id19")

--- a/src/indexer.hh
+++ b/src/indexer.hh
@@ -132,6 +132,12 @@ void reflect(BinaryWriter &visitor, SymbolRef &value);
 void reflect(BinaryWriter &visitor, Use &value);
 void reflect(BinaryWriter &visitor, DeclRef &value);
 
+enum class TokenModifier {
+#define TOKEN_MODIFIER(name, str) name,
+#include "enum.inc"
+#undef TOKEN_MODIFIER
+};
+
 template <typename T> using VectorAdapter = std::vector<T, std::allocator<T>>;
 
 template <typename D> struct NameMixin {

--- a/src/lsp.hh
+++ b/src/lsp.hh
@@ -166,6 +166,7 @@ enum class SymbolKind : uint8_t {
   // For C++, this is interpreted as "template parameter" (including
   // non-type template parameters).
   TypeParameter = 26,
+  FirstNonStandard,
 
   // ccls extensions
   // See also https://github.com/Microsoft/language-server-protocol/issues/344
@@ -174,6 +175,8 @@ enum class SymbolKind : uint8_t {
   Parameter = 253,
   StaticMethod = 254,
   Macro = 255,
+  FirstExtension = TypeAlias,
+  LastExtension = Macro,
 };
 
 struct SymbolInformation {

--- a/src/message_handler.hh
+++ b/src/message_handler.hh
@@ -41,6 +41,11 @@ struct RenameParam {
   Position position;
   std::string newName;
 };
+struct SemanticTokensRangeParams {
+  TextDocumentIdentifier textDocument;
+  lsRange range;
+};
+REFLECT_STRUCT(SemanticTokensRangeParams, textDocument, range);
 struct TextDocumentParam {
   TextDocumentIdentifier textDocument;
 };
@@ -307,6 +312,8 @@ private:
   void textDocument_rename(RenameParam &, ReplyOnce &);
   void textDocument_signatureHelp(TextDocumentPositionParam &, ReplyOnce &);
   void textDocument_typeDefinition(TextDocumentPositionParam &, ReplyOnce &);
+  void textDocument_semanticTokensFull(TextDocumentParam &, ReplyOnce &);
+  void textDocument_semanticTokensRange(SemanticTokensRangeParams &, ReplyOnce &);
   void workspace_didChangeConfiguration(EmptyParam &);
   void workspace_didChangeWatchedFiles(DidChangeWatchedFilesParam &);
   void workspace_didChangeWorkspaceFolders(DidChangeWorkspaceFoldersParam &);

--- a/src/messages/initialize.cc
+++ b/src/messages/initialize.cc
@@ -25,6 +25,51 @@
 namespace ccls {
 using namespace llvm;
 
+const char *const kTokenTypes[] = {
+    "unknown",
+
+    "file",
+    "module",
+    "namespace",
+    "package",
+    "class",
+    "method",
+    "property",
+    "field",
+    "constructor",
+    "enum",
+    "interface",
+    "function",
+    "variable",
+    "constant",
+    "string",
+    "number",
+    "boolean",
+    "array",
+    "object",
+    "key",
+    "null",
+    "enumMember",
+    "struct",
+    "event",
+    "operator",
+    "typeParameter",
+
+    // 252 => 27
+    "typeAlias",
+    "parameter",
+    "staticMethod",
+    "macro",
+};
+static_assert(std::size(kTokenTypes) ==
+              int(SymbolKind::FirstNonStandard) + int(SymbolKind::LastExtension) - int(SymbolKind::FirstExtension) + 1);
+
+const char *const kTokenModifiers[] = {
+#define TOKEN_MODIFIER(name, str) str,
+#include "enum.inc"
+#undef TOKEN_MODIFIER
+};
+
 extern std::vector<std::string> g_init_options;
 
 namespace {
@@ -89,6 +134,14 @@ struct ServerCap {
     std::vector<const char *> commands = {ccls_xref};
   } executeCommandProvider;
   bool callHierarchyProvider = true;
+  struct SemanticTokenProvider {
+    struct SemanticTokensLegend {
+      std::vector<const char *> tokenTypes{std::begin(kTokenTypes), std::end(kTokenTypes)};
+      std::vector<const char *> tokenModifiers{std::begin(kTokenModifiers), std::end(kTokenModifiers)};
+    } legend;
+    bool range = true;
+    bool full = true;
+  } semanticTokensProvider;
   Config::ServerCap::Workspace workspace;
 };
 REFLECT_STRUCT(ServerCap::CodeActionOptions, codeActionKinds);
@@ -101,16 +154,14 @@ REFLECT_STRUCT(ServerCap::SaveOptions, includeText);
 REFLECT_STRUCT(ServerCap::SignatureHelpOptions, triggerCharacters);
 REFLECT_STRUCT(ServerCap::TextDocumentSyncOptions, openClose, change, willSave,
                willSaveWaitUntil, save);
-REFLECT_STRUCT(ServerCap, textDocumentSync, hoverProvider, completionProvider,
-               signatureHelpProvider, declarationProvider, definitionProvider,
-               implementationProvider, typeDefinitionProvider,
-               referencesProvider, documentHighlightProvider,
-               documentSymbolProvider, workspaceSymbolProvider,
-               codeActionProvider, codeLensProvider, documentFormattingProvider,
-               documentRangeFormattingProvider,
-               documentOnTypeFormattingProvider, renameProvider,
-               documentLinkProvider, foldingRangeProvider,
-               executeCommandProvider, callHierarchyProvider, workspace);
+REFLECT_STRUCT(ServerCap, textDocumentSync, hoverProvider, completionProvider, signatureHelpProvider,
+               declarationProvider, definitionProvider, implementationProvider, typeDefinitionProvider,
+               referencesProvider, documentHighlightProvider, documentSymbolProvider, workspaceSymbolProvider,
+               codeActionProvider, codeLensProvider, documentFormattingProvider, documentRangeFormattingProvider,
+               documentOnTypeFormattingProvider, renameProvider, documentLinkProvider, foldingRangeProvider,
+               executeCommandProvider, callHierarchyProvider, semanticTokensProvider, workspace);
+REFLECT_STRUCT(ServerCap::SemanticTokenProvider, legend, range, full);
+REFLECT_STRUCT(ServerCap::SemanticTokenProvider::SemanticTokensLegend, tokenTypes, tokenModifiers);
 
 struct DynamicReg {
   bool dynamicRegistration = false;
@@ -133,12 +184,16 @@ struct WorkspaceClientCap {
   DynamicReg didChangeWatchedFiles;
   DynamicReg symbol;
   DynamicReg executeCommand;
+
+  struct SemanticTokensWorkspace {
+    bool refreshSupport = false;
+  } semanticTokens;
 };
 
 REFLECT_STRUCT(WorkspaceClientCap::WorkspaceEdit, documentChanges);
-REFLECT_STRUCT(WorkspaceClientCap, applyEdit, workspaceEdit,
-               didChangeConfiguration, didChangeWatchedFiles, symbol,
-               executeCommand);
+REFLECT_STRUCT(WorkspaceClientCap::SemanticTokensWorkspace, refreshSupport);
+REFLECT_STRUCT(WorkspaceClientCap, applyEdit, workspaceEdit, didChangeConfiguration, didChangeWatchedFiles, symbol,
+               executeCommand, semanticTokens);
 
 // Text document specific client capabilities.
 struct TextDocumentClientCap {
@@ -320,6 +375,7 @@ void do_initialize(MessageHandler *m, InitializeParam &param,
       capabilities.textDocument.publishDiagnostics.relatedInformation;
   didChangeWatchedFiles =
       capabilities.workspace.didChangeWatchedFiles.dynamicRegistration;
+  g_config->client.semanticTokensRefresh &= capabilities.workspace.semanticTokens.refreshSupport;
 
   if (!g_config->client.snippetSupport)
     g_config->completion.duplicateOptional = false;

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -518,6 +518,10 @@ void main_OnIndexed(DB *db, WorkingFiles *wfiles, IndexUpdate *update) {
       QueryFile &file = db->files[db->name2file_id[path]];
       emitSemanticHighlight(db, wf.get(), file);
     }
+    if (g_config->client.semanticTokensRefresh) {
+      std::optional<bool> param;
+      request("workspace/semanticTokens/refresh", param);
+    }
     return;
   }
 
@@ -534,6 +538,12 @@ void main_OnIndexed(DB *db, WorkingFiles *wfiles, IndexUpdate *update) {
       QueryFile &file = db->files[update->file_id];
       emitSkippedRanges(wfile, file);
       emitSemanticHighlight(db, wfile, file);
+      if (g_config->client.semanticTokensRefresh) {
+        // Return filename, even if the spec indicates params is none.
+        TextDocumentIdentifier param;
+        param.uri = DocumentUri::fromPath(wfile->filename);
+        request("workspace/semanticTokens/refresh", param);
+      }
     }
   }
 }


### PR DESCRIPTION
This patch implements `textDocument/semanticTokens/{full,range}`. If the client supports semantic tokens, $ccls/publishSemanticHighlight (now deprecated) is disabled.

These token modifiers are most useful to emphasize certain symbols: `static, classScope, globalScope, namespaceScope`.

The user can set the initialization option `highlight.rainbow` to 10 to enable rainbow semantic tokens.

$ccls/publishSemanticHighlight with highlight.lsRanges==true (used by vscode-ccls) is no longer supported.