### PR TITLE
resolve the type alias correctly

### DIFF
--- a/src/indexer.cc
+++ b/src/indexer.cc
@@ -325,6 +325,9 @@ try_again:
   switch (tp->getTypeClass()) {
   case Type::Typedef:
     d = cast<TypedefType>(tp)->getDecl();
+    tp = cast<TypedefType>(tp)->getDecl()->getUnderlyingType().getTypePtrOrNull();
+    if (tp)
+      goto try_again;
     break;
   case Type::ObjCObject:
     d = cast<ObjCObjectType>(tp)->getInterface();


### PR DESCRIPTION
The struct derived from an alias is missing from type hierarchy before this fix:
```cpp
struct Base {};
struct Derived : Base {};
using BaseAlias = Base;
struct DerivedAlias : BaseAlias {};
```
```
Derive from
Base
└╸Derived
```
The expected output is:
```
Derive from
Base
├╸Derived
└╸DerivedAlias
```