### PR TITLE
pipeline: avoid missing final indexing progress end

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -206,7 +206,11 @@ bool indexer_Parse(SemaManager *completion, WorkingFiles *wfiles, Project *proje
   }
 
   struct RAII {
-    ~RAII() { stats.completed++; }
+    ~RAII() {
+      stats.completed++;
+      if (main_waiter)
+        main_waiter->cv.notify_one();
+    }
   } raii;
   if (!matcher.matches(request.path)) {
     LOG_IF_S(INFO, loud) << "skip " << request.path;
@@ -756,10 +760,13 @@ void mainLoop() {
         freeUnusedMemory();
         has_indexed = false;
       }
+      auto progress_changed = [&last_completed]() {
+        return stats.completed.load(std::memory_order_relaxed) != last_completed;
+      };
       if (backlog.empty())
-        main_waiter->wait(g_quit, on_indexed, on_request);
+        main_waiter->waitWithCondition(g_quit, progress_changed, on_indexed, on_request);
       else
-        main_waiter->waitUntil(backlog[0].deadline, on_indexed, on_request);
+        main_waiter->waitUntilWithCondition(backlog[0].deadline, progress_changed, on_indexed, on_request);
     }
   }
 

--- a/src/threaded_queue.hh
+++ b/src/threaded_queue.hh
@@ -51,10 +51,20 @@ struct MultiQueueWaiter {
     return false;
   }
 
+  template <typename Predicate>
+  static bool shouldWake(Predicate &predicate, std::initializer_list<BaseThreadQueue *> queues) {
+    return predicate() || hasState(queues);
+  }
+
   template <typename... BaseThreadQueue> bool wait(std::atomic<bool> &quit, BaseThreadQueue... queues) {
+    return waitWithCondition(quit, [] { return false; }, queues...);
+  }
+
+  template <typename Predicate, typename... BaseThreadQueue>
+  bool waitWithCondition(std::atomic<bool> &quit, Predicate &&predicate, BaseThreadQueue... queues) {
     MultiQueueLock<BaseThreadQueue...> l(queues...);
     while (!quit.load(std::memory_order_relaxed)) {
-      if (hasState({queues...}))
+      if (shouldWake(predicate, {queues...}))
         return false;
       cv.wait(l);
     }
@@ -63,8 +73,14 @@ struct MultiQueueWaiter {
 
   template <typename... BaseThreadQueue>
   void waitUntil(std::chrono::steady_clock::time_point t, BaseThreadQueue... queues) {
+    waitUntilWithCondition(t, [] { return false; }, queues...);
+  }
+
+  template <typename Predicate, typename... BaseThreadQueue>
+  void waitUntilWithCondition(std::chrono::steady_clock::time_point t, Predicate &&predicate,
+                              BaseThreadQueue... queues) {
     MultiQueueLock<BaseThreadQueue...> l(queues...);
-    if (!hasState({queues...}))
+    if (!shouldWake(predicate, {queues...}))
       cv.wait_until(l, t);
   }
 };


### PR DESCRIPTION
## Summary
- wake the main loop after `stats.completed` advances so the final indexing completion is not silent
- extend `MultiQueueWaiter` with predicate-aware wait helpers and use them for index progress tracking
- prevent the last `completed == enqueued` transition from being missed, which can otherwise suppress the final `$/progress end`

## Test plan
- [x] Build `ccls` locally with Clang CMake packages available
- [x] Reproduce indexing on a large workspace and confirm the final `$/progress end` arrives
- [x] Inspect the `pipeline.cc` and `threaded_queue.hh` control flow for the lost-wakeup race
